### PR TITLE
Migrate deprecated org.apache.camel.main.BaseMainSupport#addRouteBuilder(org.apache.camel.RoutesBuilder)

### DIFF
--- a/examples/camel-example-artemis/src/main/java/org/apache/camel/example/artemis/ArtemisMain.java
+++ b/examples/camel-example-artemis/src/main/java/org/apache/camel/example/artemis/ArtemisMain.java
@@ -38,10 +38,10 @@ public final class ArtemisMain {
         main.bind("artemis", createArtemisComponent());
 
         // add the widget/gadget route
-        main.addRouteBuilder(new WidgetGadgetRoute());
+        main.addRoutesBuilder(new WidgetGadgetRoute());
 
         // add a 2nd route that routes files from src/data to the order queue
-        main.addRouteBuilder(new CreateOrderRoute());
+        main.addRoutesBuilder(new CreateOrderRoute());
 
         // start and run Camel (block)
         main.run();

--- a/examples/camel-example-debezium/src/main/java/org/apache/camel/example/debezium/KinesisProducerToCassandra.java
+++ b/examples/camel-example-debezium/src/main/java/org/apache/camel/example/debezium/KinesisProducerToCassandra.java
@@ -44,7 +44,7 @@ public final class KinesisProducerToCassandra {
         LOG.debug("About to run Kinesis to Cassandra integration...");
 
         // add route
-        main.addRouteBuilder(new RouteBuilder() {
+        main.addRoutesBuilder(new RouteBuilder() {
             public void configure() {
                 // We set the CQL templates we need, note that an UPDATE in Cassandra means an UPSERT which is what we need
                 final String cqlUpdate = "update products set name = ?, description = ?, weight = ? where id = ?";

--- a/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpClient.java
+++ b/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpClient.java
@@ -28,7 +28,7 @@ public final class MyFtpClient {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRouteBuilder(new MyFtpClientRouteBuilder());
+        main.addRoutesBuilder(new MyFtpClientRouteBuilder());
         main.run();
     }
 

--- a/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpServer.java
+++ b/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpServer.java
@@ -28,7 +28,7 @@ public final class MyFtpServer {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRouteBuilder(new MyFtpServerRouteBuilder());
+        main.addRoutesBuilder(new MyFtpServerRouteBuilder());
         main.run();
     }
 

--- a/examples/camel-example-kotlin/src/main/kotlin/org/apache/camel/example/MainApp.kt
+++ b/examples/camel-example-kotlin/src/main/kotlin/org/apache/camel/example/MainApp.kt
@@ -30,6 +30,6 @@ fun main(args: Array<String>) {
     System.out.println("\n\n\n\n");
 
     val main = Main()
-    main.addRouteBuilder(MyRouteBuilder())
+    main.addRoutesBuilder(MyRouteBuilder())
     main.run(args)
 }

--- a/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/LoanBroker.java
+++ b/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/LoanBroker.java
@@ -33,7 +33,7 @@ public final class LoanBroker {
         // configure the location of the Spring XML file
 
         main.setApplicationContextUri("META-INF/spring/server.xml");
-        main.addRouteBuilder(new LoanBrokerRoute());
+        main.addRoutesBuilder(new LoanBrokerRoute());
 
         main.run();
     }

--- a/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyClient.java
+++ b/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyClient.java
@@ -33,7 +33,7 @@ public final class MyClient {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRouteBuilder(new MyRouteBuilder());
+        main.addRoutesBuilder(new MyRouteBuilder());
 
         // setup correlation manager and its timeout (when a request has not received a response within the given time millis)
         MyCorrelationManager manager = new MyCorrelationManager();

--- a/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyServer.java
+++ b/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyServer.java
@@ -29,7 +29,7 @@ public final class MyServer {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRouteBuilder(new MyRouteBuilder());
+        main.addRoutesBuilder(new MyRouteBuilder());
         main.bind("myEncoder", new MyCodecEncoderFactory());
         main.bind("myDecoder", new MyCodecDecoderFactory());
         main.run(args);

--- a/examples/camel-example-spark-rest/src/main/java/org/apache/camel/example/spark/UserMain.java
+++ b/examples/camel-example-spark-rest/src/main/java/org/apache/camel/example/spark/UserMain.java
@@ -27,7 +27,7 @@ public final class UserMain {
     public static void main(String[] args) throws Exception {
         Main main = new Main();
         main.bind("userService", new UserService());
-        main.addRouteBuilder(new UserRouteBuilder());
+        main.addRoutesBuilder(new UserRouteBuilder());
         main.run();
     }
 }

--- a/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSavedSearchClient.java
+++ b/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSavedSearchClient.java
@@ -30,7 +30,7 @@ public final class SplunkSavedSearchClient {
     public static void main(String[] args) throws Exception {
         LOG.info("About to run splunk-camel integration...");
         Main main = new Main();
-        main.addRouteBuilder(new SplunkSavedSearchRouteBuilder());
+        main.addRoutesBuilder(new SplunkSavedSearchRouteBuilder());
         main.run();
     }
 }

--- a/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSearchClient.java
+++ b/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSearchClient.java
@@ -30,7 +30,7 @@ public final class SplunkSearchClient {
     public static void main(String[] args) throws Exception {
         LOG.info("About to run splunk-camel integration...");
         Main main = new Main();
-        main.addRouteBuilder(new SplunkSearchRouteBuilder());
+        main.addRoutesBuilder(new SplunkSearchRouteBuilder());
         main.run();
     }
 

--- a/examples/camel-example-twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
+++ b/examples/camel-example-twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
@@ -68,7 +68,7 @@ public final class CamelTwitterWebSocketMain {
         route.setPort(9090);
 
         // add our routes to Camel
-        main.addRouteBuilder(route);
+        main.addRoutesBuilder(route);
 
         // and run, which keeps blocking until we terminate the JVM (or stop CamelContext)
         main.run();

--- a/examples/camel-example-widget-gadget-java/src/main/java/org/apache/camel/example/widget/WidgetMain.java
+++ b/examples/camel-example-widget-gadget-java/src/main/java/org/apache/camel/example/widget/WidgetMain.java
@@ -36,10 +36,10 @@ public final class WidgetMain {
         main.bind("activemq", createActiveMQComponent());
 
         // add the widget/gadget route
-        main.addRouteBuilder(new WidgetGadgetRoute());
+        main.addRoutesBuilder(new WidgetGadgetRoute());
 
         // add a 2nd route that routes files from src/main/data to the order queue
-        main.addRouteBuilder(new CreateOrderRoute());
+        main.addRoutesBuilder(new CreateOrderRoute());
 
         // start and run Camel (block)
         main.run();


### PR DESCRIPTION
Hi!

It's my first contribution - let me know if something is missing or doesn't follow project contribution guidelines.

It's quite a minor change. All examples using deprecated method
org.apache.camel.main.BaseMainSupport#addRouteBuilder(org.apache.camel.RoutesBuilder) 
updated to use org.apache.camel.main.BaseMainSupport#addRoutesBuilder as suggested by documentation.
