### PR TITLE
Fixed examples camel main class

### DIFF
--- a/examples/camel-example-artemis/src/main/java/org/apache/camel/example/artemis/ArtemisMain.java
+++ b/examples/camel-example-artemis/src/main/java/org/apache/camel/example/artemis/ArtemisMain.java
@@ -38,10 +38,10 @@ public final class ArtemisMain {
         main.bind("artemis", createArtemisComponent());
 
         // add the widget/gadget route
-        main.addRoutesBuilder(new WidgetGadgetRoute());
+        main.configure().addRoutesBuilder(new WidgetGadgetRoute());
 
         // add a 2nd route that routes files from src/data to the order queue
-        main.addRoutesBuilder(new CreateOrderRoute());
+        main.configure().addRoutesBuilder(new CreateOrderRoute());
 
         // start and run Camel (block)
         main.run();

--- a/examples/camel-example-debezium/src/main/java/org/apache/camel/example/debezium/DebeziumMySqlConsumerToKinesis.java
+++ b/examples/camel-example-debezium/src/main/java/org/apache/camel/example/debezium/DebeziumMySqlConsumerToKinesis.java
@@ -46,7 +46,7 @@ public final class DebeziumMySqlConsumerToKinesis {
         LOG.debug("About to run Debezium integration...");
 
         // add route
-        main.addRoutesBuilder(new RouteBuilder() {
+        main.configure().addRoutesBuilder(new RouteBuilder() {
             public void configure() {
                 // Initial Debezium route that will run and listens to the changes,
                 // first it will perform an initial snapshot using (select * from) in case there are no offsets

--- a/examples/camel-example-debezium/src/main/java/org/apache/camel/example/debezium/KinesisProducerToCassandra.java
+++ b/examples/camel-example-debezium/src/main/java/org/apache/camel/example/debezium/KinesisProducerToCassandra.java
@@ -44,7 +44,7 @@ public final class KinesisProducerToCassandra {
         LOG.debug("About to run Kinesis to Cassandra integration...");
 
         // add route
-        main.addRoutesBuilder(new RouteBuilder() {
+        main.configure().addRoutesBuilder(new RouteBuilder() {
             public void configure() {
                 // We set the CQL templates we need, note that an UPDATE in Cassandra means an UPSERT which is what we need
                 final String cqlUpdate = "update products set name = ?, description = ?, weight = ? where id = ?";

--- a/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpClient.java
+++ b/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpClient.java
@@ -28,7 +28,7 @@ public final class MyFtpClient {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRoutesBuilder(new MyFtpClientRouteBuilder());
+        main.configure().addRoutesBuilder(new MyFtpClientRouteBuilder());
         main.run();
     }
 

--- a/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpServer.java
+++ b/examples/camel-example-ftp/src/main/java/org/apache/camel/example/ftp/MyFtpServer.java
@@ -28,7 +28,7 @@ public final class MyFtpServer {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRoutesBuilder(new MyFtpServerRouteBuilder());
+        main.configure().addRoutesBuilder(new MyFtpServerRouteBuilder());
         main.run();
     }
 

--- a/examples/camel-example-java8/src/main/java/org/apache/camel/example/java8/MyApplication.java
+++ b/examples/camel-example-java8/src/main/java/org/apache/camel/example/java8/MyApplication.java
@@ -34,7 +34,7 @@ public final class MyApplication {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRoutesBuilder(new MyRouteBuilder());
+        main.configure().addRoutesBuilder(new MyRouteBuilder());
         main.run(args);
     }
 

--- a/examples/camel-example-kotlin/src/main/kotlin/org/apache/camel/example/MainApp.kt
+++ b/examples/camel-example-kotlin/src/main/kotlin/org/apache/camel/example/MainApp.kt
@@ -30,6 +30,6 @@ fun main(args: Array<String>) {
     System.out.println("\n\n\n\n");
 
     val main = Main()
-    main.addRoutesBuilder(MyRouteBuilder())
+    main.configure().addRoutesBuilder(MyRouteBuilder())
     main.run(args)
 }

--- a/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/LoanBroker.java
+++ b/examples/camel-example-loan-broker-jms/src/main/java/org/apache/camel/loanbroker/LoanBroker.java
@@ -33,7 +33,7 @@ public final class LoanBroker {
         // configure the location of the Spring XML file
 
         main.setApplicationContextUri("META-INF/spring/server.xml");
-        main.addRoutesBuilder(new LoanBrokerRoute());
+        main.configure().addRoutesBuilder(new LoanBrokerRoute());
 
         main.run();
     }

--- a/examples/camel-example-main-artemis/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/camel-example-main-artemis/src/main/java/org/apache/camel/example/MyApplication.java
@@ -31,9 +31,9 @@ public final class MyApplication {
         Main main = new Main();
         // lets use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
-        main.addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfigurationClass(MyConfiguration.class);
         // and add the routes (you can specify multiple classes)
-        main.addRouteBuilder(MyRouteBuilder.class);
+        main.configure().addRoutesBuilder(MyRouteBuilder.class);
         // now keep the application running until the JVM is terminated (ctrl + c or sigterm)
         main.run(args);
     }

--- a/examples/camel-example-main-tiny/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/camel-example-main-tiny/src/main/java/org/apache/camel/example/MyApplication.java
@@ -30,7 +30,7 @@ public final class MyApplication {
         // use Camels Main class
         Main main = new Main();
         // and add the routes (you can specify multiple classes)
-        main.addRouteBuilder(MyRouteBuilder.class);
+        main.configure().addRoutesBuilder(MyRouteBuilder.class);
         // now keep the application running until the JVM is terminated (ctrl + c or sigterm)
         main.run(args);
     }

--- a/examples/camel-example-main-xml/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/camel-example-main-xml/src/main/java/org/apache/camel/example/MyApplication.java
@@ -31,7 +31,7 @@ public final class MyApplication {
         Main main = new Main();
         // lets use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
-        main.addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfigurationClass(MyConfiguration.class);
         // and add all the XML routes
         main.configure().withXmlRoutes("routes/*.xml");
 

--- a/examples/camel-example-main/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/camel-example-main/src/main/java/org/apache/camel/example/MyApplication.java
@@ -31,9 +31,9 @@ public final class MyApplication {
         Main main = new Main();
         // lets use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
-        main.addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfigurationClass(MyConfiguration.class);
         // and add the routes (you can specify multiple classes)
-        main.addRouteBuilder(MyRouteBuilder.class);
+        main.configure().addRoutesBuilder(MyRouteBuilder.class);
         // now keep the application running until the JVM is terminated (ctrl + c or sigterm)
         main.run(args);
     }

--- a/examples/camel-example-mongodb/src/main/java/org/apache/camel/example/mongodb/Application.java
+++ b/examples/camel-example-mongodb/src/main/java/org/apache/camel/example/mongodb/Application.java
@@ -37,9 +37,9 @@ public final class Application {
         main = new Main();
         // bind connectionBean used by the component
         main.bind("myDb", MongoClients.create("mongodb://localhost"));
-        main.addRoutesBuilder(new MongoDBFindByIDRouteBuilder());
-        main.addRoutesBuilder(new MongoDBFindAllRouteBuilder());
-        main.addRoutesBuilder(new MongoDBInsertRouteBuilder());
+        main.configure().addRoutesBuilder(new MongoDBFindByIDRouteBuilder());
+        main.configure().addRoutesBuilder(new MongoDBFindAllRouteBuilder());
+        main.configure().addRoutesBuilder(new MongoDBInsertRouteBuilder());
         System.out.println("Starting Camel. Use CTRL + C to terminate the process.\n");
         main.run();
     }

--- a/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyClient.java
+++ b/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyClient.java
@@ -33,7 +33,7 @@ public final class MyClient {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRoutesBuilder(new MyRouteBuilder());
+        main.configure().addRoutesBuilder(new MyRouteBuilder());
 
         // setup correlation manager and its timeout (when a request has not received a response within the given time millis)
         MyCorrelationManager manager = new MyCorrelationManager();

--- a/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyServer.java
+++ b/examples/camel-example-netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyServer.java
@@ -29,7 +29,7 @@ public final class MyServer {
 
     public static void main(String[] args) throws Exception {
         Main main = new Main();
-        main.addRoutesBuilder(new MyRouteBuilder());
+        main.configure().addRoutesBuilder(new MyRouteBuilder());
         main.bind("myEncoder", new MyCodecEncoderFactory());
         main.bind("myDecoder", new MyCodecDecoderFactory());
         main.run(args);

--- a/examples/camel-example-reactive-executor-vertx/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/camel-example-reactive-executor-vertx/src/main/java/org/apache/camel/example/MyApplication.java
@@ -30,7 +30,7 @@ public final class MyApplication {
         // use Camels Main class
         Main main = new Main();
         // and add the routes (you can specify multiple classes)
-        main.addRouteBuilder(MyRouteBuilder.class);
+        main.configure().addRoutesBuilder(MyRouteBuilder.class);
         // now keep the application running until the JVM is terminated (ctrl + c or sigterm)
         main.run(args);
     }

--- a/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSavedSearchClient.java
+++ b/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSavedSearchClient.java
@@ -30,7 +30,7 @@ public final class SplunkSavedSearchClient {
     public static void main(String[] args) throws Exception {
         LOG.info("About to run splunk-camel integration...");
         Main main = new Main();
-        main.addRoutesBuilder(new SplunkSavedSearchRouteBuilder());
+        main.configure().addRoutesBuilder(new SplunkSavedSearchRouteBuilder());
         main.run();
     }
 }

--- a/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSearchClient.java
+++ b/examples/camel-example-splunk/src/main/java/org/apache/camel/example/splunk/SplunkSearchClient.java
@@ -30,7 +30,7 @@ public final class SplunkSearchClient {
     public static void main(String[] args) throws Exception {
         LOG.info("About to run splunk-camel integration...");
         Main main = new Main();
-        main.addRoutesBuilder(new SplunkSearchRouteBuilder());
+        main.configure().addRoutesBuilder(new SplunkSearchRouteBuilder());
         main.run();
     }
 

--- a/examples/camel-example-twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
+++ b/examples/camel-example-twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
@@ -68,7 +68,7 @@ public final class CamelTwitterWebSocketMain {
         route.setPort(9090);
 
         // add our routes to Camel
-        main.addRoutesBuilder(route);
+        main.configure().addRoutesBuilder(route);
 
         // and run, which keeps blocking until we terminate the JVM (or stop CamelContext)
         main.run();

--- a/examples/camel-example-widget-gadget-java/src/main/java/org/apache/camel/example/widget/WidgetMain.java
+++ b/examples/camel-example-widget-gadget-java/src/main/java/org/apache/camel/example/widget/WidgetMain.java
@@ -36,10 +36,10 @@ public final class WidgetMain {
         main.bind("activemq", createActiveMQComponent());
 
         // add the widget/gadget route
-        main.addRoutesBuilder(new WidgetGadgetRoute());
+        main.configure().addRoutesBuilder(new WidgetGadgetRoute());
 
         // add a 2nd route that routes files from src/main/data to the order queue
-        main.addRoutesBuilder(new CreateOrderRoute());
+        main.configure().addRoutesBuilder(new CreateOrderRoute());
 
         // start and run Camel (block)
         main.run();


### PR DESCRIPTION
Trying to build examples for the master branch found out that the new "configure()" method was missing. So added it to make the examples buildable.