### PR TITLE
CAMEL-15379: Fix failing cdi examples tests

### DIFF
--- a/examples/camel-example-cdi-properties/src/test/java/org/apache/camel/example/cdi/properties/CdiPropertiesTest.java
+++ b/examples/camel-example-cdi-properties/src/test/java/org/apache/camel/example/cdi/properties/CdiPropertiesTest.java
@@ -23,21 +23,21 @@ import org.apache.camel.cdi.Uri;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.reifier.RouteReifier;
-import org.apache.camel.spi.CamelEvent.CamelContextStartingEvent;
+import org.apache.camel.spi.CamelEvent.CamelContextStartedEvent;
 import org.apache.camel.test.cdi.CamelCdiRunner;
 import org.apache.deltaspike.core.api.config.ConfigProperty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(CamelCdiRunner.class)
 public class CdiPropertiesTest {
 
-    static void advice(@Observes CamelContextStartingEvent event,
+    static void advice(@Observes CamelContextStartedEvent event,
                        ModelCamelContext context) throws Exception {
         // Add a mock endpoint to the end of the route
         RouteReifier.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {

--- a/examples/camel-example-cdi-xml/src/test/java/org/apache/camel/example/cdi/xml/CdiXmlTest.java
+++ b/examples/camel-example-cdi-xml/src/test/java/org/apache/camel/example/cdi/xml/CdiXmlTest.java
@@ -32,7 +32,7 @@ import org.apache.camel.cdi.Uri;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.reifier.RouteReifier;
-import org.apache.camel.spi.CamelEvent.CamelContextStartingEvent;
+import org.apache.camel.spi.CamelEvent.CamelContextStartedEvent;
 import org.apache.camel.test.cdi.CamelCdiRunner;
 import org.apache.camel.test.cdi.Order;
 import org.awaitility.Awaitility;
@@ -40,6 +40,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+
+
 
 @RunWith(CamelCdiRunner.class)
 public class CdiXmlTest {
@@ -51,7 +53,7 @@ public class CdiXmlTest {
     @Inject
     private ProducerTemplate prompt;
 
-    void pipeMatrixStream(@Observes CamelContextStartingEvent event,
+    void pipeMatrixStream(@Observes CamelContextStartedEvent event,
                           ModelCamelContext context) throws Exception {
         RouteReifier
             .adviceWith(context.getRouteDefinition("matrix"), context, new AdviceWithRouteBuilder() {

--- a/examples/camel-example-cxf-proxy/pom.xml
+++ b/examples/camel-example-cxf-proxy/pom.xml
@@ -137,6 +137,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-codegen-plugin</artifactId>
+                <version>${cxf-codegen-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>

--- a/examples/camel-example-cxf/pom.xml
+++ b/examples/camel-example-cxf/pom.xml
@@ -294,6 +294,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-codegen-plugin</artifactId>
+                <version>${cxf-codegen-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>


### PR DESCRIPTION
Hello,
Changing the @Observers events from `CamelContext**Starting**Event` to `CamelContext**Started**Event` fixes the tests 
I don't know why though ... was there a change in the behavior of CamelContext Events ?
