### PR TITLE
Fix MessageConsumerClient subscription

### DIFF
--- a/examples/camel-example-kafka/src/main/java/org/apache/camel/example/kafka/MessageConsumerClient.java
+++ b/examples/camel-example-kafka/src/main/java/org/apache/camel/example/kafka/MessageConsumerClient.java
@@ -50,7 +50,7 @@ public final class MessageConsumerClient {
                         .register(camelContext, "kafka");
 
                 from("kafka:{{consumer.topic}}"
-                        + "&maxPollRecords={{consumer.maxPollRecords}}"
+                        + "?maxPollRecords={{consumer.maxPollRecords}}"
                         + "&consumersCount={{consumer.consumersCount}}"
                         + "&seekTo={{consumer.seekTo}}"
                         + "&groupId={{consumer.group}}")


### PR DESCRIPTION
Resolving 
Error while fetching metadata with correlation id 2: {TestLog&maxPollRecords=5000&consumersCount=1&seekTo=beginning&groupId=kafkaGroup=INVALID_TOPIC_EXCEPTION}