### PR TITLE
improve the scripts of camel-example-spring-security

### DIFF
--- a/examples/camel-example-spring-security/client/access-admin-as-jim.sh
+++ b/examples/camel-example-spring-security/client/access-admin-as-jim.sh
@@ -18,5 +18,6 @@
 
 rm -rf work
 mkdir work
-wget --http-user=jim --http-password=jimspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel/admin
+POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+wget --http-user=jim --http-password=jimspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/admin
 cat -n work/* | less

--- a/examples/camel-example-spring-security/client/access-admin-no-auth.sh
+++ b/examples/camel-example-spring-security/client/access-admin-no-auth.sh
@@ -19,5 +19,5 @@
 rm -rf work
 mkdir work
 POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --http-user=bob --http-password=bobspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/admin
+wget --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/admin
 cat -n work/* | less

--- a/examples/camel-example-spring-security/client/access-user-as-bob.sh
+++ b/examples/camel-example-spring-security/client/access-user-as-bob.sh
@@ -19,5 +19,5 @@
 rm -rf work
 mkdir work
 POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --http-user=bob --http-password=bobspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/admin
+wget --http-user=bob --http-password=bobspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/user
 cat -n work/* | less

--- a/examples/camel-example-spring-security/client/access-user-as-jim.sh
+++ b/examples/camel-example-spring-security/client/access-user-as-jim.sh
@@ -18,5 +18,6 @@
 
 rm -rf work
 mkdir work
-wget --http-user=jim --http-password=jimspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel/user
+POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+wget --http-user=jim --http-password=jimspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/user
 cat -n work/* | less

--- a/examples/camel-example-spring-security/client/access-user-no-auth.sh
+++ b/examples/camel-example-spring-security/client/access-user-no-auth.sh
@@ -18,5 +18,6 @@
 
 rm -rf work
 mkdir work
-wget --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel/user
+POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+wget --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/user
 cat -n work/* | less


### PR DESCRIPTION
All the scripts were non-working as the context root-path was missing by all of them.

Verified the changes using `apache-tomcat-9.0.36`.