### PR TITLE
Add missing camel-bean dependency

### DIFF
--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -50,15 +50,17 @@
     </dependencyManagement>
 
     <dependencies>
-
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-file</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-bean</artifactId>
         </dependency>
 
         <dependency>

--- a/examples/spring/src/test/java/org/apache/camel/example/spring/IntegrationTest.java
+++ b/examples/spring/src/test/java/org/apache/camel/example/spring/IntegrationTest.java
@@ -26,6 +26,6 @@ public class IntegrationTest extends Assert {
     public void testCamelRulesDeployCorrectlyInSpring() throws Exception {
         // let's boot up the Spring application context for 2 seconds to check that it works OK
         Main main = new Main();
-        main.run(new String[]{"-duration", "2s", "-o", "target/site/cameldoc"});
+        main.run(new String[]{"-duration", "2s"});
     }
 }


### PR DESCRIPTION
- Example couldn't run because of the missing dependency. In apache-camel version 3.7.x artifact camel-bean was located in camel-spring (as transitive dependency) which is not the case in the version 3.9.0-SNAPSHOT.

[ERROR] Failed to execute goal org.apache.camel:camel-maven-plugin:3.9.0-SNAPSHOT:run (default-cli) on project camel-example-spring: null: MojoExecutionException: InvocationTargetException: Failed to create route route3 at: >>> Bean[org.apache.camel.example.spring.MyRouteBuilder$SomeBean] <<< in route: Route(route3)[From[file://target/test?noop=true] -> [Bean[or... because of Cannot find BeanProcessorFactory on classpath. Add camel-bean to classpath. -> [Help 1]

- Additionally IntegrationTest was falsy correct because the argument option '"-o", "target/site/cameldoc"' caused the Main class to fail silently.

[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.camel.example.spring.IntegrationTest
Unknown option: -o

Apache Camel Runner takes the following options

  -h or -help = Displays the help screen
  -r or -routers <routerBuilderClasses> = Sets the router builder classes which will be loaded while starting the camel context
  -d or -duration <duration> = Sets the time duration (seconds) that the application will run for before terminating.
  -dm or -durationMaxMessages <durationMaxMessages> = Sets the duration of maximum number of messages that the application will process before terminating.
  -di or -durationIdle <durationIdle> = Sets the idle time duration (seconds) duration that the application can be idle before terminating.
  -t or -trace = Enables tracing
  -e or -exitcode <exitcode> = Sets the exit code if duration was hit
  -pl or -propertiesLocation <propertiesLocation> = Sets location(s) to load properties, such as from classpath or file system.
  -ac or -applicationContext <applicationContext> = Sets the classpath based spring ApplicationContext
  -fa or -fileApplicationContext <fileApplicationContext> = Sets the filesystem based spring ApplicationContext
  -ac or -applicationContext <applicationContext> = Sets the classpath based spring ApplicationContext
  -fa or -fileApplicationContext <fileApplicationContext> = Sets the filesystem based spring ApplicationContext
  -ac or -applicationContext <applicationContext> = Sets the classpath based spring ApplicationContext
  -fa or -fileApplicationContext <fileApplicationContext> = Sets the filesystem based spring ApplicationContext
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.627 s - in org.apache.camel.example.spring.IntegrationTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

-> Adding camel-bean solved the problem
