### PR TITLE
cfx-proxy: Fix Starup error because file:target/custom.properties is missing

### DIFF
--- a/examples/cxf-proxy/src/main/resources/META-INF/spring/camel-config.xml
+++ b/examples/cxf-proxy/src/main/resources/META-INF/spring/camel-config.xml
@@ -57,7 +57,8 @@
   <camelContext xmlns="http://camel.apache.org/schema/spring">
 
     <!-- property which contains port number -->
-    <propertyPlaceholder id="properties" location="classpath:incident.properties,file:target/custom.properties"/>
+    <propertyPlaceholder id="properties" location="classpath:incident.properties,file:target/custom.properties"
+                         ignoreMissingLocation="true"/>
 
     <endpoint id="callRealWebService" uri="http://localhost:${real.port}/real-webservice?throwExceptionOnFailure=false"/>
 


### PR DESCRIPTION
FYI: 20 years ago I used to be rleland@apache.org since I am a first time contributor, but I had them deactivate that account in 2005.