### PR TITLE
CAMEL-16576: fix README links to support and community pages

### DIFF
--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -212,9 +212,9 @@ Number of Examples: 91 (0 deprecated)
 == Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/activemq-tomcat/README.adoc
+++ b/examples/activemq-tomcat/README.adoc
@@ -47,9 +47,9 @@ The ActiveMQ broker is configured in the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aggregate-dist/README.adoc
+++ b/examples/aggregate-dist/README.adoc
@@ -17,9 +17,9 @@ $ mvn clean compile exec:java
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aggregate/README.adoc
+++ b/examples/aggregate/README.adoc
@@ -58,9 +58,9 @@ it uses a persistent store.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/any23/README.adoc
+++ b/examples/any23/README.adoc
@@ -30,9 +30,9 @@ You can find more information about Apache Camel at the website: http://camel.ap
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/artemis-large-messages/README.adoc
+++ b/examples/artemis-large-messages/README.adoc
@@ -86,9 +86,9 @@ delete all messages from queues which is a handy operation.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/artemis/README.adoc
+++ b/examples/artemis/README.adoc
@@ -97,9 +97,9 @@ The Camel application is configured in the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/as2/README.adoc
+++ b/examples/as2/README.adoc
@@ -29,9 +29,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/aws-secrets-manager/README.adoc
+++ b/examples/aws/aws-secrets-manager/README.adoc
@@ -54,9 +54,9 @@ At this point you should see:
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-aws2-s3-kafka/README.adoc
+++ b/examples/aws/main-endpointdsl-aws2-s3-kafka/README.adoc
@@ -24,9 +24,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-aws2-s3/README.adoc
+++ b/examples/aws/main-endpointdsl-aws2-s3/README.adoc
@@ -24,9 +24,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-aws2/README.adoc
+++ b/examples/aws/main-endpointdsl-aws2/README.adoc
@@ -67,9 +67,9 @@ In the aws2-sqs-consumer terminal you should see a createBucket event in the log
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-aws2/aws2-eventbridge-creator/readme.adoc
+++ b/examples/aws/main-endpointdsl-aws2/aws2-eventbridge-creator/readme.adoc
@@ -19,9 +19,9 @@ You can run this example using
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/readme.adoc
+++ b/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/readme.adoc
@@ -19,9 +19,9 @@ You can run this example using
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-aws2/aws2-sqs-consumer/readme.adoc
+++ b/examples/aws/main-endpointdsl-aws2/aws2-sqs-consumer/readme.adoc
@@ -19,9 +19,9 @@ You can run this example using
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/README.adoc
+++ b/examples/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/README.adoc
@@ -63,9 +63,9 @@ Now in the same s3.topic.1/partition_0 folder, you should see 20 files correctly
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/aws/main-endpointdsl-kafka-aws2-s3/README.adoc
+++ b/examples/aws/main-endpointdsl-kafka-aws2-s3/README.adoc
@@ -53,9 +53,9 @@ You should see the bucket populated.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/azure-eventhubs/README.adoc
+++ b/examples/azure-eventhubs/README.adoc
@@ -22,9 +22,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/azure-storage-blob/README.adoc
+++ b/examples/azure-storage-blob/README.adoc
@@ -35,9 +35,9 @@ To stop the example hit `ctrl+c`
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/basic/README.adoc
+++ b/examples/basic/README.adoc
@@ -37,9 +37,9 @@ and then right click, and chose run java application.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/bigxml-split/README.adoc
+++ b/examples/bigxml-split/README.adoc
@@ -70,9 +70,9 @@ Tested on MacBook Pro 2,8 GHz Intel Core i7; 16 GB 2133 MHz LPDDR3; Java
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/billboard-aggregate/README.adoc
+++ b/examples/billboard-aggregate/README.adoc
@@ -48,9 +48,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cafe-endpointdsl/README.adoc
+++ b/examples/cafe-endpointdsl/README.adoc
@@ -46,9 +46,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cafe/README.adoc
+++ b/examples/cafe/README.adoc
@@ -45,9 +45,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cassandra-kubernetes/README.adoc
+++ b/examples/cassandra-kubernetes/README.adoc
@@ -131,9 +131,9 @@ No resources found.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-cassandraql/README.adoc
+++ b/examples/cdi-cassandraql/README.adoc
@@ -158,9 +158,9 @@ cqlsh:test>
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-kubernetes/README.adoc
+++ b/examples/cdi-kubernetes/README.adoc
@@ -82,9 +82,9 @@ The Camel application can be stopped pressing ctrl+c in the shell.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-metrics/README.adoc
+++ b/examples/cdi-metrics/README.adoc
@@ -85,9 +85,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-minio/README.adoc
+++ b/examples/cdi-minio/README.adoc
@@ -37,9 +37,9 @@ The Camel application can be stopped pressing ctrl+c in the shell.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-properties/README.adoc
+++ b/examples/cdi-properties/README.adoc
@@ -66,9 +66,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-rest-servlet/README.adoc
+++ b/examples/cdi-rest-servlet/README.adoc
@@ -90,9 +90,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-test/README.adoc
+++ b/examples/cdi-test/README.adoc
@@ -74,9 +74,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi-xml/README.adoc
+++ b/examples/cdi-xml/README.adoc
@@ -121,9 +121,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cdi/README.adoc
+++ b/examples/cdi/README.adoc
@@ -37,9 +37,9 @@ CDI container is created and started.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/console/README.adoc
+++ b/examples/console/README.adoc
@@ -42,9 +42,9 @@ and then right click, and chose run java application.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/csimple-joor/readme.adoc
+++ b/examples/csimple-joor/readme.adoc
@@ -28,9 +28,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/csimple/readme.adoc
+++ b/examples/csimple/readme.adoc
@@ -29,9 +29,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cxf-proxy/README.adoc
+++ b/examples/cxf-proxy/README.adoc
@@ -83,9 +83,9 @@ file `+src/main/resources/incident.properties+`
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cxf-tomcat/README.adoc
+++ b/examples/cxf-tomcat/README.adoc
@@ -68,9 +68,9 @@ within soapUI, making sample SOAP requests such as the following:
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/cxf/README.adoc
+++ b/examples/cxf/README.adoc
@@ -61,9 +61,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/debezium-eventhubs-blob/README.adoc
+++ b/examples/debezium-eventhubs-blob/README.adoc
@@ -108,9 +108,9 @@ You can enable verbose logging by adjusting the `src/main/resources/log4j2.prope
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/debezium/README.adoc
+++ b/examples/debezium/README.adoc
@@ -105,9 +105,9 @@ You can enable verbose logging by adjusting the `src/main/resources/log4j2.prope
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/fhir/README.adoc
+++ b/examples/fhir/README.adoc
@@ -58,9 +58,9 @@ The Camel application can be stopped pressing ctrl+c in the shell.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/flight-recorder/README.adoc
+++ b/examples/flight-recorder/README.adoc
@@ -40,9 +40,9 @@ In the `application.properties` file.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/ftp/README.adoc
+++ b/examples/ftp/README.adoc
@@ -59,9 +59,9 @@ You can enable verbose logging by adjustung the `src/main/resources/log4j.proper
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/hazelcast-kubernetes/README.adoc
+++ b/examples/hazelcast-kubernetes/README.adoc
@@ -250,9 +250,9 @@ No resources found.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/java8/README.adoc
+++ b/examples/java8/README.adoc
@@ -25,9 +25,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/jdbc/README.adoc
+++ b/examples/jdbc/README.adoc
@@ -43,9 +43,9 @@ update the record as DONE so not to re-process on next polled.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/jms-file/README.adoc
+++ b/examples/jms-file/README.adoc
@@ -31,9 +31,9 @@ the test directory.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/jmx/README.adoc
+++ b/examples/jmx/README.adoc
@@ -35,9 +35,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/jooq/README.adoc
+++ b/examples/jooq/README.adoc
@@ -67,9 +67,9 @@ And the consumer route `consume-route` selects and deletes all entities from dat
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/kafka/README.adoc
+++ b/examples/kafka/README.adoc
@@ -69,9 +69,9 @@ You can enable verbose logging by adjusting the `src/main/resources/log4j2.prope
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/kamelet/README.adoc
+++ b/examples/kamelet/README.adoc
@@ -31,9 +31,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/kotlin/README.adoc
+++ b/examples/kotlin/README.adoc
@@ -26,9 +26,9 @@ http://localhost:8080
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/loadbalancing/README.adoc
+++ b/examples/loadbalancing/README.adoc
@@ -60,9 +60,9 @@ mvn exec:java -Ploadbalancer
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/loan-broker-cxf/README.adoc
+++ b/examples/loan-broker-cxf/README.adoc
@@ -40,9 +40,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/loan-broker-jms/README.adoc
+++ b/examples/loan-broker-jms/README.adoc
@@ -46,9 +46,9 @@ $ mvn test
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-artemis/README.adoc
+++ b/examples/main-artemis/README.adoc
@@ -29,9 +29,9 @@ $ mvn compile camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-endpointdsl-google-pubsub/README.adoc
+++ b/examples/main-endpointdsl-google-pubsub/README.adoc
@@ -36,9 +36,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-endpointdsl/README.adoc
+++ b/examples/main-endpointdsl/README.adoc
@@ -27,9 +27,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-health/README.adoc
+++ b/examples/main-health/README.adoc
@@ -32,9 +32,9 @@ find the DefaultHealthCheck MBean.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-joor/README.adoc
+++ b/examples/main-joor/README.adoc
@@ -14,9 +14,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-lambda/README.adoc
+++ b/examples/main-lambda/README.adoc
@@ -27,9 +27,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-tiny/README.adoc
+++ b/examples/main-tiny/README.adoc
@@ -18,9 +18,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main-xml/README.adoc
+++ b/examples/main-xml/README.adoc
@@ -16,9 +16,9 @@ You can run this example using
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/main/README.adoc
+++ b/examples/main/README.adoc
@@ -35,9 +35,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/management/README.adoc
+++ b/examples/management/README.adoc
@@ -83,9 +83,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/micrometer/README.adoc
+++ b/examples/micrometer/README.adoc
@@ -72,9 +72,9 @@ You can see the routing rules by looking at the java code in the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/mongodb/README.adoc
+++ b/examples/mongodb/README.adoc
@@ -42,9 +42,9 @@ $ curl localhost:8081/hello?id=5eaa94933aff184354c4a874
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/netty-custom-correlation/README.adoc
+++ b/examples/netty-custom-correlation/README.adoc
@@ -32,9 +32,9 @@ Also the messages can be inter-leaved when some messages are faster than others.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/oaipmh/README.adoc
+++ b/examples/oaipmh/README.adoc
@@ -25,9 +25,9 @@ You can find more information about Apache Camel at the website: http://camel.ap
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/openapi-cdi/README.adoc
+++ b/examples/openapi-cdi/README.adoc
@@ -50,9 +50,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/pojo-messaging/README.adoc
+++ b/examples/pojo-messaging/README.adoc
@@ -27,9 +27,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/reactive-executor-vertx/README.adoc
+++ b/examples/reactive-executor-vertx/README.adoc
@@ -19,9 +19,9 @@ You can find more information about Apache Camel at the website: http://camel.ap
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/route-throttling/README.adoc
+++ b/examples/route-throttling/README.adoc
@@ -65,9 +65,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/routeloader/README.adoc
+++ b/examples/routeloader/README.adoc
@@ -23,9 +23,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/routetemplate/README.adoc
+++ b/examples/routetemplate/README.adoc
@@ -23,9 +23,9 @@ $ mvn camel:run
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/salesforce-consumer/README.adoc
+++ b/examples/salesforce-consumer/README.adoc
@@ -58,9 +58,9 @@ You can specify your topic name (`salesforce.topic`) and turn on/off each operat
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/servlet-tomcat/README.adoc
+++ b/examples/servlet-tomcat/README.adoc
@@ -36,9 +36,9 @@ http://localhost:8080/camel-example-servlet-tomcat/camel/hello
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/splunk/README.adoc
+++ b/examples/splunk/README.adoc
@@ -60,9 +60,9 @@ You can enable verbose logging by adjusting the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/spring-javaconfig/README.adoc
+++ b/examples/spring-javaconfig/README.adoc
@@ -34,9 +34,9 @@ You can see the routing rules by looking at the java code in the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/spring-pulsar/README.adoc
+++ b/examples/spring-pulsar/README.adoc
@@ -57,9 +57,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/spring-security/README.adoc
+++ b/examples/spring-security/README.adoc
@@ -34,9 +34,9 @@ user/password (`+jim/jimspassword+` with the admin and user role or
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/spring-ws/README.adoc
+++ b/examples/spring-ws/README.adoc
@@ -34,9 +34,9 @@ use SOAP-UI project available in the `+client+` directory.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/spring-xquery/README.adoc
+++ b/examples/spring-xquery/README.adoc
@@ -35,9 +35,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/spring/README.adoc
+++ b/examples/spring/README.adoc
@@ -33,9 +33,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/swagger-cdi/README.adoc
+++ b/examples/swagger-cdi/README.adoc
@@ -59,9 +59,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/telegram/README.adoc
+++ b/examples/telegram/README.adoc
@@ -17,9 +17,9 @@ You can specify your "chat id" and "authorization token" in "application.propert
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/transformer-cdi/README.adoc
+++ b/examples/transformer-cdi/README.adoc
@@ -32,9 +32,9 @@ CDI container is created and started.
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/transformer-demo/README.adoc
+++ b/examples/transformer-demo/README.adoc
@@ -31,9 +31,9 @@ Check the `+src/main/resources/log4j2.properties+`
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/twitter-websocket/README.adoc
+++ b/examples/twitter-websocket/README.adoc
@@ -39,9 +39,9 @@ To stop the example hit ctrl+c
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/vertx-kafka/README.adoc
+++ b/examples/vertx-kafka/README.adoc
@@ -57,9 +57,9 @@ You can enable verbose logging by adjusting the `src/main/resources/log4j2.prope
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, 
-then please https://camel.apache.org/support.html[let us know].
+then please https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, 
-so https://camel.apache.org/contributing.html[get involved] :-)
+so https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/widget-gadget-cdi/README.adoc
+++ b/examples/widget-gadget-cdi/README.adoc
@@ -89,9 +89,9 @@ The Camel application is configured in the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/widget-gadget-java/README.adoc
+++ b/examples/widget-gadget-java/README.adoc
@@ -87,9 +87,9 @@ The Camel application is configured in the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!

--- a/examples/widget-gadget-xml/README.adoc
+++ b/examples/widget-gadget-xml/README.adoc
@@ -88,9 +88,9 @@ The Camel application is configured in the
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please
-https://camel.apache.org/support.html[let us know].
+https://camel.apache.org/community/support/[let us know].
 
 We also love contributors, so
-https://camel.apache.org/contributing.html[get involved] :-)
+https://camel.apache.org/community/contributing/[get involved] :-)
 
 The Camel riders!


### PR DESCRIPTION
All the README.adoc files pointed to the support and contributing.html pages in the Camel user manual which have been removed in CAMEL-16576. I changed them to link to https://camel.apache.org/community/support/ and /community/contributing/.