### PR TITLE
CAMEL-16256: fix pom.xml to allow spring-ws example to run

### DIFF
--- a/examples/spring-ws/pom.xml
+++ b/examples/spring-ws/pom.xml
@@ -25,7 +25,6 @@
         <groupId>org.apache.camel.example</groupId>
         <artifactId>examples</artifactId>
         <version>3.10.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-example-spring-ws</artifactId>

--- a/examples/spring-ws/pom.xml
+++ b/examples/spring-ws/pom.xml
@@ -25,6 +25,7 @@
         <groupId>org.apache.camel.example</groupId>
         <artifactId>examples</artifactId>
         <version>3.10.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-example-spring-ws</artifactId>
@@ -56,6 +57,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-ws</artifactId>
         </dependency>
+        <!--  Required to avoid org.apache.camel.NoSuchLanguageException for "simple" -->
+       <dependency>
+    		<groupId>org.apache.camel</groupId>
+    		<artifactId>camel-core-languages</artifactId>
+ 	    </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jaxb</artifactId>
@@ -63,13 +69,6 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-xml</artifactId>
-        </dependency>
-
-        <!-- for running inside a servlet container -->
-        <dependency>
-            <groupId>org.springframework.ws</groupId>
-            <artifactId>spring-ws-core</artifactId>
-            <version>${spring-ws-version}</version>
         </dependency>
         <dependency>
             <groupId>wsdl4j</groupId>
@@ -146,5 +145,34 @@
         </plugins>
 
     </build>
+    <profiles>
+      <profile>
+            <id>jdk9s-build</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+        
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.ws</groupId>
+                    <artifactId>jaxws-api</artifactId>
+                    <version>2.3.0</version>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.messaging.saaj</groupId>
+                    <artifactId>saaj-impl</artifactId>
+                    <version>1.3.28</version>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>javax.xml.soap</groupId>
+                            <artifactId>javax.xml.soap-api</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+      </profiles>
 
 </project>


### PR DESCRIPTION
Removed org.springframework.ws dependency causing incompatible versions of spring jars; it's included from the camel-spring-ws component.
Added camel-core-languages dependency to fix another deployment error.
Added jdk9 profile to include jars not present and required at runtime.