### PR TITLE
Promote the new way to ref a bean from Endpoint URI

### DIFF
--- a/examples/netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyClient.java
+++ b/examples/netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyClient.java
@@ -82,8 +82,8 @@ public final class MyClient {
                 .log("Request:  ${id}:${body}")
                 // call netty server using a single shared connection and using custom correlation manager
                 // to ensure we can correltly map the request and response pairs
-                .to("netty:tcp://localhost:4444?sync=true&encoders=#myEncoder&decoders=#myDecoder"
-                    + "&producerPoolEnabled=false&correlationManager=#myManager")
+                .to("netty:tcp://localhost:4444?sync=true&encoders=#bean:myEncoder&decoders=#bean:myDecoder"
+                    + "&producerPoolEnabled=false&correlationManager=#bean:myManager")
                 // log response after
                 .log("Response: ${id}:${body}");
         }

--- a/examples/netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyServer.java
+++ b/examples/netty-custom-correlation/src/main/java/org/apache/camel/example/netty/MyServer.java
@@ -39,7 +39,7 @@ public final class MyServer {
 
         @Override
         public void configure() throws Exception {
-            from("netty:tcp://localhost:4444?sync=true&encoders=#myEncoder&decoders=#myDecoder")
+            from("netty:tcp://localhost:4444?sync=true&encoders=#bean:myEncoder&decoders=#bean:myDecoder")
                 .log("Request:  ${id}:${body}")
                 .filter(simple("${body} contains 'beer'"))
                     // use some delay when its beer to make responses interleaved

--- a/examples/spring-ws/src/main/java/org/apache/camel/example/server/IncrementRoute.java
+++ b/examples/spring-ws/src/main/java/org/apache/camel/example/server/IncrementRoute.java
@@ -29,7 +29,7 @@ public class IncrementRoute extends RouteBuilder {
     public void configure() throws Exception {
         JaxbDataFormat jaxb = new JaxbDataFormat(IncrementRequest.class.getPackage().getName());
         
-        from("spring-ws:rootqname:{http://camel.apache.org/example/increment}incrementRequest?endpointMapping=#endpointMapping")
+        from("spring-ws:rootqname:{http://camel.apache.org/example/increment}incrementRequest?endpointMapping=#bean:endpointMapping")
             .unmarshal(jaxb)
             .process(new IncrementProcessor())
             .marshal(jaxb);


### PR DESCRIPTION
## Motivation

A new way of referring beans from Endpoint URIs exist and should be promoted as the old way is now deprecated according to https://camel.apache.org/manual/faq/how-do-i-configure-endpoints.html#HowdoIconfigureendpoints-ReferringbeansfromEndpointURIs

## Modifications

* Modifies the examples that refer to beans from an Endpoint URI to use the new prefix `#bean:`