### PR TITLE
Ensure that the main class for CDI apps is called by the plugin

### DIFF
--- a/examples/cdi-test/pom.xml
+++ b/examples/cdi-test/pom.xml
@@ -63,7 +63,7 @@
         <!-- Camel CDI -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-cdi</artifactId>
+            <artifactId>camel-cdi-main</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/examples/cdi/pom.xml
+++ b/examples/cdi/pom.xml
@@ -62,7 +62,7 @@
         <!-- Camel CDI -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-cdi</artifactId>
+            <artifactId>camel-cdi-main</artifactId>
         </dependency>
 
         <dependency>

--- a/examples/fhir/pom.xml
+++ b/examples/fhir/pom.xml
@@ -63,7 +63,7 @@
         <!-- Camel -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-cdi</artifactId>
+            <artifactId>camel-cdi-main</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
## Motivation

All examples that rely on Camel CDI don't start, they fail with the following error:

```
[INFO] --- camel-maven-plugin:3.15.0-SNAPSHOT:run (default-cli) @ camel-example-cdi ---
[INFO] You can skip tests from the command line using: mvn camel:run -Dmaven.test.skip=true
[INFO] Using org.apache.camel.spring.Main to initiate a CamelContext
[INFO] Starting Camel ...
[ERROR] *************************************
[ERROR] Error occurred while running main from: org.apache.camel.spring.Main
[ERROR] 
java.lang.ClassNotFoundException: org.apache.camel.spring.Main
    at java.net.URLClassLoader.findClass (URLClassLoader.java:471)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:589)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:522)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:400)
    at java.lang.Thread.run (Thread.java:829)
[ERROR] *************************************
```
This error is due to the fact that the way the plugin auto detects CDI apps has changed, now it expects that the project has the artifact `camel-cdi-main` as compile dependency

## Modifications:

* Replaces `camel-cdi` with `camel-cdi-main` where it is needed
