### PR TITLE
Fix the CNFE in the jOOQ example

### DIFF
--- a/examples/jooq/pom.xml
+++ b/examples/jooq/pom.xml
@@ -56,6 +56,10 @@
         <!-- Camel -->
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-main</artifactId>
         </dependency>
         <dependency>
@@ -92,30 +96,9 @@
         </dependency>
         <!-- Database access -->
         <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-            <version>${jooq-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <version>${commons-dbcp-version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <version>${hsqldb-version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${spring-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-            <version>${spring-version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Motivation

When we launch the jOOQ example thanks to the command `mvn camel:run` with Java 11, we get the next error:

```
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.JAXBException
    at java.net.URLClassLoader.findClass (URLClassLoader.java:471)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:589)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:522)
    at java.lang.Class.getDeclaredConstructors0 (Native Method)
    at java.lang.Class.privateGetDeclaredConstructors (Class.java:3137)
    at java.lang.Class.getConstructor0 (Class.java:3342)
    at java.lang.Class.getDeclaredConstructor (Class.java:2553)
    at org.springframework.beans.BeanUtils.instantiateClass (BeanUtils.java:146)
    at org.springframework.beans.factory.xml.DefaultNamespaceHandlerResolver.resolve (DefaultNamespaceHandlerResolver.java:134)
    at org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseCustomElement (BeanDefinitionParserDelegate.java:1386)
    at org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseCustomElement (BeanDefinitionParserDelegate.java:1371)
    at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseBeanDefinitions (DefaultBeanDefinitionDocumentReader.java:179)
    at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions (DefaultBeanDefinitionDocumentReader.java:149)
    at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions (DefaultBeanDefinitionDocumentReader.java:96)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions (XmlBeanDefinitionReader.java:511)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions (XmlBeanDefinitionReader.java:391)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions (XmlBeanDefinitionReader.java:338)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions (XmlBeanDefinitionReader.java:310)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:196)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:232)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:203)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:265)
    at org.springframework.context.support.AbstractXmlApplicationContext.loadBeanDefinitions (AbstractXmlApplicationContext.java:128)
    at org.springframework.context.support.AbstractXmlApplicationContext.loadBeanDefinitions (AbstractXmlApplicationContext.java:94)
    at org.springframework.context.support.AbstractRefreshableApplicationContext.refreshBeanFactory (AbstractRefreshableApplicationContext.java:130)
    at org.springframework.context.support.AbstractApplicationContext.obtainFreshBeanFactory (AbstractApplicationContext.java:671)
    at org.springframework.context.support.AbstractApplicationContext.refresh (AbstractApplicationContext.java:553)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:144)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:95)
    at org.apache.camel.spring.Main.createDefaultApplicationContext (Main.java:289)
    at org.apache.camel.spring.Main.doStart (Main.java:195)
    at org.apache.camel.support.service.BaseService.start (BaseService.java:119)
    at org.apache.camel.main.MainSupport.run (MainSupport.java:69)
    at org.apache.camel.main.MainCommandLineSupport.run (MainCommandLineSupport.java:174)
    at org.apache.camel.spring.Main.main (Main.java:97)

```

## Modifications:

* Add the dependency `camel-core` to add `jakarta.xml.bind-api` by transitivity
* Clean up the dependencies to prevent conflicts by removing `jooq` and `commons-dbcp` as they are already transitive dependencies of `camel-jooq`
* Clean up the dependencies to prevent conflicts by removing `spring-context` as it is already a transitive dependency of `camel-spring-xml`
* Remove the dependency `spring-jdbc` as it is not used

## Result

The example can be launched successfully and provides an output of type:

```
2022-01-24 10:32:07,125 [ing.Main.main()] INFO  AbstractCamelContext           - Routes startup (total:2 started:2)
2022-01-24 10:32:07,127 [ing.Main.main()] INFO  AbstractCamelContext           -     Started produce-route (timer://insert)
2022-01-24 10:32:07,128 [ing.Main.main()] INFO  AbstractCamelContext           -     Started consume-route (jooq://org.apache.camel.examples.jooq.db.tables.records.BookStoreRecord)
2022-01-24 10:32:07,128 [ing.Main.main()] INFO  AbstractCamelContext           - Apache Camel 3.15.0-SNAPSHOT (camel-1) started in 231ms (build:47ms init:150ms start:34ms)
2022-01-24 10:32:08,241 [ timer://insert] INFO  Constants                      - 
                                      
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@  @@        @@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@        @@@@@@@@@@
@@@@@@@@@@@@@@@@  @@  @@    @@@@@@@@@@
@@@@@@@@@@  @@@@  @@  @@    @@@@@@@@@@
@@@@@@@@@@        @@        @@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@        @@        @@@@@@@@@@
@@@@@@@@@@    @@  @@  @@@@  @@@@@@@@@@
@@@@@@@@@@    @@  @@  @@@@  @@@@@@@@@@
@@@@@@@@@@        @@  @  @  @@@@@@@@@@
@@@@@@@@@@        @@        @@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@  @@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  Thank you for using jOOQ 3.16.2
                                      
2022-01-24 10:32:08,247 [ timer://insert] INFO  Constants                      - 

jOOQ tip of the day: Want to aggregate multiple values per group? Use the synthetic MULTISET_AGG aggregate function! https://www.jooq.org/doc/latest/manual/sql-building/column-expressions/aggregate-functions/multiset-agg-function/

2022-01-24 10:32:08,716 [ timer://insert] INFO  ENGINE                         - Database closed
2022-01-24 10:32:08,882 [ timer://insert] INFO  produce-route                  - Inserted: +------------------+
|NAME              |
+------------------+
|test_1643016728133|
+------------------+

2022-01-24 10:32:08,889 [BookStoreRecord] INFO  consume-route                  - Consumed: +-------------------------+
|NAME                     |
+-------------------------+
|Buchhandlung im Volkshaus|
+-------------------------+


``` 