### PR TITLE
Fix the BeanDefinitionParsingException in management and route-throttling examples

### DIFF
--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-spring-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-jms</artifactId>
         </dependency>
         <dependency>

--- a/examples/route-throttling/pom.xml
+++ b/examples/route-throttling/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-spring-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-activemq</artifactId>
             <!-- lets use JMS 2.0 api but camel-jms still works with ActiveMQ 5.x that is JMS 1.1 only -->
             <exclusions>


### PR DESCRIPTION
## Motivation

When launching the examples `management` and `route-throttling`, we end up with an error of type:

```
org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Unable to locate Spring NamespaceHandler for XML schema namespace [http://camel.apache.org/schema/spring]
Offending resource: file [/Users/nicolasfilotto/projects/camel/camel-examples/examples/management/target/classes/META-INF/spring/camel-context.xml]

    at org.springframework.beans.factory.parsing.FailFastProblemReporter.error (FailFastProblemReporter.java:72)
    at org.springframework.beans.factory.parsing.ReaderContext.error (ReaderContext.java:119)
    at org.springframework.beans.factory.parsing.ReaderContext.error (ReaderContext.java:111)
    at org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.error (BeanDefinitionParserDelegate.java:281)
    at org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseCustomElement (BeanDefinitionParserDelegate.java:1388)
    at org.springframework.beans.factory.xml.BeanDefinitionParserDelegate.parseCustomElement (BeanDefinitionParserDelegate.java:1371)
    at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseBeanDefinitions (DefaultBeanDefinitionDocumentReader.java:179)
    at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions (DefaultBeanDefinitionDocumentReader.java:149)
    at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions (DefaultBeanDefinitionDocumentReader.java:96)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions (XmlBeanDefinitionReader.java:511)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions (XmlBeanDefinitionReader.java:391)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions (XmlBeanDefinitionReader.java:338)
    at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions (XmlBeanDefinitionReader.java:310)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:196)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:232)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:203)
    at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions (AbstractBeanDefinitionReader.java:265)
    at org.springframework.context.support.AbstractXmlApplicationContext.loadBeanDefinitions (AbstractXmlApplicationContext.java:128)
    at org.springframework.context.support.AbstractXmlApplicationContext.loadBeanDefinitions (AbstractXmlApplicationContext.java:94)
    at org.springframework.context.support.AbstractRefreshableApplicationContext.refreshBeanFactory (AbstractRefreshableApplicationContext.java:130)
    at org.springframework.context.support.AbstractApplicationContext.obtainFreshBeanFactory (AbstractApplicationContext.java:671)
    at org.springframework.context.support.AbstractApplicationContext.refresh (AbstractApplicationContext.java:553)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:144)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:95)
    at org.apache.camel.spring.Main.createDefaultApplicationContext (Main.java:289)
    at org.apache.camel.spring.Main.doStart (Main.java:195)
    at org.apache.camel.support.service.BaseService.start (BaseService.java:119)
    at org.apache.camel.main.MainSupport.run (MainSupport.java:69)
    at org.apache.camel.main.MainCommandLineSupport.run (MainCommandLineSupport.java:174)
    at org.apache.camel.spring.Main.main (Main.java:97)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:401)
    at java.lang.Thread.run (Thread.java:829)
```

## Modifications:

* Adds `camel-spring-xml` to the dependencies of those projects.

## Result

The examples can be launched without errors