### PR TITLE
Allow the health check to flip between UP and DOWN

### DIFF
--- a/examples/main-health/src/main/java/org/apache/camel/example/MonkeyHealthCheck.java
+++ b/examples/main-health/src/main/java/org/apache/camel/example/MonkeyHealthCheck.java
@@ -32,7 +32,7 @@ import org.apache.camel.spi.annotations.HealthCheck;
 @HealthCheck("monkey-check")
 public class MonkeyHealthCheck extends AbstractHealthCheck {
 
-    private boolean up = true;
+    private static boolean up = true;
 
     public MonkeyHealthCheck() {
         super("custom", "monkey");
@@ -48,7 +48,7 @@ public class MonkeyHealthCheck extends AbstractHealthCheck {
          }
     }
 
-    public String chaos() {
+    public static String chaos() {
         up = !up;
         return up ? "All is okay" : "Chaos monkey was here";
     }

--- a/examples/main-health/src/main/java/org/apache/camel/example/MyRouteBuilder.java
+++ b/examples/main-health/src/main/java/org/apache/camel/example/MyRouteBuilder.java
@@ -16,22 +16,16 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.health.HealthCheck;
-import org.apache.camel.health.HealthCheckResolver;
 
 public class MyRouteBuilder extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
         // to trigger the health check to flip between UP and DOWN then lets call it as a Java bean from
-        // a route, and therefore we need to lookup and resolve the monkey-check
-        HealthCheckResolver resolver = getCamelContext().adapt(ExtendedCamelContext.class).getHealthCheckResolver();
-        final HealthCheck monkey = resolver.resolveHealthCheck("monkey");
-
+        // a route
         from("timer:foo?period={{myPeriod}}").routeId("timer")
-            .bean(monkey, "chaos")
+            .bean(MonkeyHealthCheck.class, "chaos")
             .log("${body}");
 
         // this route is invalid and fails during startup


### PR DESCRIPTION
## Motivation

The `MonkeyHealthCheck` of the example `main-health` is always UP while it is supposed to flip between UP and DOWN.

## Modifications

It appears that the code actually tries to get the `MonkeyHealthCheck` instance from `HealthCheckResolver#resolveHealthCheck` which returns a different instance at each call while the correct instance is registered into the `HealthCheckRegistry`. However even if we change the code to get it from the `HealthCheckRegistry`, it doesn't work either because the routes are configured before the loading of the health checks (postProcessCamelContext vs context init).

So as workaround, this PR proposes to rely on a static field instead of a member field.

* Make the field `MonkeyHealthCheck#up` static
* Remove (incorrect) the code used to get the instance of `MonkeyHealthCheck` that will be called by the BeanProcessor

## Result

The `MonkeyHealthCheck` can really flip between UP and DOWN

DOWN

![DOWN](https://user-images.githubusercontent.com/1618116/151212211-aa63770c-b5b4-4381-916d-b69c98a75c9a.png)

UP

![UP](https://user-images.githubusercontent.com/1618116/151212315-0ae85bbd-7262-4c30-8ace-aa7a5f6631d7.png)


