### PR TITLE
Fix route reload configuration

### DIFF
--- a/examples/main-xml/src/main/resources/application.properties
+++ b/examples/main-xml/src/main/resources/application.properties
@@ -25,9 +25,9 @@ camel.main.routes-include-pattern = routes/*.xml
 # turn on route reloading on file changes
 camel.main.routes-reload-enabled = true
 # the base directory to watch
-camel.main.routes-reload-directory = src/main/resources
+camel.main.routes-reload-directory = src/main/resources/routes
 # pattern(s) for files to watch
-camel.main.routes-reload-pattern = routes/*.xml
+camel.main.routes-reload-pattern = *.xml
 
 # properties used in the route
 myCron = 0/2 * * * * ?

--- a/examples/main-yaml/src/main/resources/application.properties
+++ b/examples/main-yaml/src/main/resources/application.properties
@@ -22,9 +22,9 @@ camel.main.name = MyYamlCamel
 # turn on route reloading on file changes
 camel.main.routes-reload-enabled = true
 # the base directory to watch
-camel.main.routes-reload-directory = src/main/resources
+camel.main.routes-reload-directory = src/main/resources/routes
 # pattern(s) for files to watch
-camel.main.routes-reload-pattern = routes/*.yaml
+camel.main.routes-reload-pattern = *.yaml
 # on reload should all existing routes be removed first
 camel.main.routes-reload-remove-all-routes = true
 


### PR DESCRIPTION
## Motivation

In the examples `main-xml` and `main-yaml`, the routes are not automatically reloaded when the route file is modified while the route reloading feature is enabled.

## Modifications

Since, by default the option `camel.main.routes-reload-directory-recursive` is set to `false` and the option `camel.main.routes-reload-directory` has been set to `src/main/resources`, the modifications of a file in the directory `routes` can not be detected.

* Modifies the base directory to watch in order to detect modifications in the route file. 