### PR TITLE
Fix compilation errors in routeloader and YAML validation errors in routeloader/kamelet-main/routes-configuration

### DIFF
--- a/examples/kamelet-main/src/main/resources/camel/my-route.yaml
+++ b/examples/kamelet-main/src/main/resources/camel/my-route.yaml
@@ -1,7 +1,8 @@
 - route:
     id: "earthquake"
-    from: "kamelet:earthquake-source"
-    steps:
-      - unmarshal:
-          json: {}
-      - log: "Earthquake with magnitude ${body[properties][mag]} at ${body[properties][place]}"
+    from:
+      uri: "kamelet:earthquake-source"
+      steps:
+        - unmarshal:
+            json: {}
+        - log: "Earthquake with magnitude ${body[properties][mag]} at ${body[properties][place]}"

--- a/examples/routeloader/pom.xml
+++ b/examples/routeloader/pom.xml
@@ -61,6 +61,12 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-java-joor-dsl</artifactId>
         </dependency>
+        <!-- the endpoint dsl to be able to dynamically compile MyRouteBuilder.java -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-endpointdsl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <!-- xml-io with fast xml route loader -->
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/examples/routeloader/src/main/resources/myroutes/my-yaml-route.yaml
+++ b/examples/routeloader/src/main/resources/myroutes/my-yaml-route.yaml
@@ -16,12 +16,13 @@
 ## ---------------------------------------------------------------------------
 
 - route:
-    from: "timer:yaml?period=3s"
-    steps:
-      - set-body:
-          simple: "Timer fired ${header.CamelTimerCounter} times"
-      - to:
-          uri: "log:yaml"
-          parameters:
-            show-body-type: false
-            show-exchange-pattern: false
+    from:
+      uri: "timer:yaml?period=3s"
+      steps:
+        - set-body:
+            simple: "Timer fired ${header.CamelTimerCounter} times"
+        - to:
+            uri: "log:yaml"
+            parameters:
+              show-body-type: false
+              show-exchange-pattern: false

--- a/examples/routes-configuration/src/main/resources/myroutes/my-yaml-route.yaml
+++ b/examples/routes-configuration/src/main/resources/myroutes/my-yaml-route.yaml
@@ -18,15 +18,16 @@
 - route:
     # refer to the route configuration by the id to use for this route
     route-configuration-id: "yamlError"
-    from: "timer:yaml?period=3s"
-    steps:
-      - set-body:
-          simple: "Timer fired ${header.CamelTimerCounter} times"
-      - to:
-          uri: "log:yaml"
-          parameters:
-            show-body-type: false
-            show-exchange-pattern: false
-      - throw-exception:
-          exception-type: "java.lang.IllegalArgumentException"
-          message: "Error from yaml"
+    from:
+      uri: "timer:yaml?period=3s"
+      steps:
+        - set-body:
+            simple: "Timer fired ${header.CamelTimerCounter} times"
+        - to:
+            uri: "log:yaml"
+            parameters:
+              show-body-type: false
+              show-exchange-pattern: false
+        - throw-exception:
+            exception-type: "java.lang.IllegalArgumentException"
+            message: "Error from yaml"


### PR DESCRIPTION
## Motivation

When we try to run the example `routeloader`, we get a compilation error due to a missing dependency and if we fix it, we finally get a YAML validation error of the following type:

```
ERROR] *************************************
[ERROR] Error occurred while running main from: org.apache.camel.main.Main
[ERROR] 
java.lang.reflect.InvocationTargetException
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:401)
    at java.lang.Thread.run (Thread.java:829)
Caused by: org.apache.camel.dsl.yaml.common.exception.UnsupportedFieldException: Unsupported field (steps) for node: <org.snakeyaml.engine.v2.nodes.MappingNode (tag=tag:yaml.org,2002:map, values={ key=<org.snakeyaml.engine.v2.nodes.ScalarNode (tag=tag:yaml.org,2002:str, value=from)>; value=<NodeTuple keyNode=<org.snakeyaml.engine.v2.nodes.ScalarNode (tag=tag:yaml.org,2002:str, value=from)>; valueNode=<org.snakeyaml.engine.v2.nodes.ScalarNode (tag=tag:yaml.org,2002:str, value=timer:yaml?period=3s)>> }{ key=<org.snakeyaml.engine.v2.nodes.ScalarNode (tag=tag:yaml.org,2002:str, value=steps)>; value=475262681 })>
    at org.apache.camel.dsl.yaml.deserializers.RouteDefinitionDeserializer.setProperties (RouteDefinitionDeserializer.java:84)
    at org.apache.camel.dsl.yaml.deserializers.RouteDefinitionDeserializer.setProperties (RouteDefinitionDeserializer.java:33)
    at org.apache.camel.dsl.yaml.common.YamlDeserializerBase.construct (YamlDeserializerBase.java:60)
    at org.apache.camel.dsl.yaml.common.YamlDeserializationContext$2.construct (YamlDeserializationContext.java:231)
    at org.apache.camel.dsl.yaml.YamlRoutesBuilderLoader$1.configuration (YamlRoutesBuilderLoader.java:192)
    at org.apache.camel.builder.RouteConfigurationBuilder.addRouteConfigurationsToCamelContext (RouteConfigurationBuilder.java:77)
    at org.apache.camel.impl.engine.AbstractCamelContext.addRoutesConfigurations (AbstractCamelContext.java:1177)
    at org.apache.camel.main.RoutesConfigurer.addDiscoveredRoutes (RoutesConfigurer.java:228)
    at org.apache.camel.main.RoutesConfigurer.configureRoutes (RoutesConfigurer.java:209)
    at org.apache.camel.main.BaseMainSupport.configureRoutes (BaseMainSupport.java:512)
    at org.apache.camel.main.BaseMainSupport.postProcessCamelContext (BaseMainSupport.java:557)
    at org.apache.camel.main.MainSupport.initCamelContext (MainSupport.java:371)
    at org.apache.camel.main.Main.doInit (Main.java:107)
    at org.apache.camel.support.service.BaseService.init (BaseService.java:83)
    at org.apache.camel.main.MainSupport.run (MainSupport.java:65)
    at org.apache.camel.main.MainCommandLineSupport.run (MainCommandLineSupport.java:174)
    at org.apache.camel.main.Main.main (Main.java:44)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:401)
```

## Modifications:

* Add the missing dependency (`amel-endpointds`) that is needed at runtime
* Move the `steps` into the `from` node and move the `uri` to the dedicated property to fix the YAML validation issues in routeloader/kamelet-main/routes-configuration