### PR TITLE
Fix NoSuchLanguageException in spring-security

### DIFF
--- a/examples/spring-security/pom.xml
+++ b/examples/spring-security/pom.xml
@@ -52,6 +52,10 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring-xml</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Motivation

When we deploy the war file from the example spring-security, we get the next error at startup:

```
org.apache.camel.NoSuchLanguageException: No language could be found for: simple
	at org.apache.camel.impl.engine.DefaultLanguageResolver.noSpecificLanguageFound(DefaultLanguageResolver.java:89) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.DefaultLanguageResolver.resolveLanguage(DefaultLanguageResolver.java:63) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.AbstractCamelContext$4.apply(AbstractCamelContext.java:1821) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.AbstractCamelContext$4.apply(AbstractCamelContext.java:1804) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705) ~[?:?]
	at org.apache.camel.impl.engine.AbstractCamelContext.resolveLanguage(AbstractCamelContext.java:1804) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.AbstractCamelContext.doStartStandardServices(AbstractCamelContext.java:3800) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.AbstractCamelContext.forceLazyInitialization(AbstractCamelContext.java:3738) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.AbstractCamelContext.doInit(AbstractCamelContext.java:2813) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.support.service.BaseService.init(BaseService.java:83) ~[camel-api-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.AbstractCamelContext.init(AbstractCamelContext.java:2585) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.support.service.BaseService.start(BaseService.java:111) ~[camel-api-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.engine.AbstractCamelContext.start(AbstractCamelContext.java:2604) ~[camel-base-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.impl.DefaultCamelContext.start(DefaultCamelContext.java:247) ~[camel-core-engine-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.spring.SpringCamelContext.start(SpringCamelContext.java:119) ~[camel-spring-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.spring.xml.CamelContextFactoryBean.start(CamelContextFactoryBean.java:430) ~[camel-spring-xml-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.spring.xml.CamelContextFactoryBean.onApplicationEvent(CamelContextFactoryBean.java:485) ~[camel-spring-xml-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.apache.camel.spring.xml.CamelContextFactoryBean.onApplicationEvent(CamelContextFactoryBean.java:99) ~[camel-spring-xml-3.15.0-SNAPSHOT.jar:3.15.0-SNAPSHOT]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:176) ~[spring-context-5.3.15.jar:5.3.15]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:169) ~[spring-context-5.3.15.jar:5.3.15]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:143) ~[spring-context-5.3.15.jar:5.3.15]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:421) ~[spring-context-5.3.15.jar:5.3.15]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:378) ~[spring-context-5.3.15.jar:5.3.15]
	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:938) ~[spring-context-5.3.15.jar:5.3.15]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:586) ~[spring-context-5.3.15.jar:5.3.15]
	at org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:401) ~[spring-web-5.3.15.jar:5.3.15]
	at org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:292) [spring-web-5.3.15.jar:5.3.15]
	at org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:103) [spring-web-5.3.15.jar:5.3.15]
	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4768) [catalina.jar:9.0.56]
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5230) [catalina.jar:9.0.56]
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183) [catalina.jar:9.0.56]
	at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:726) [catalina.jar:9.0.56]
	at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:698) [catalina.jar:9.0.56]

```

## Modifications:

* Add (by transitivity) the missing artifact `camel-core-languages` by adding `camel-core`