### PR TITLE
Fix the content of the spring-xquery output file

### DIFF
--- a/examples/spring-xquery/src/main/resources/myTransform.xquery
+++ b/examples/spring-xquery/src/main/resources/myTransform.xquery
@@ -15,6 +15,6 @@
     limitations under the License.
 :)
 <employee id="{person/@user}">
- <name>{/person/firstName} {/person/lastName}</name>
- <location>{/person/city}</location>
+ <name>{/person/firstName/text()}&#32;{/person/lastName/text()}</name>
+ <location>{/person/city/text()}</location>
 </employee>


### PR DESCRIPTION
## Motivation

The XML output file of the example `spring-xquery` doesn't seem to be what is really expected and thus should be fixed.

Indeed the expected content is:
```
<employee id="james">
    <name>James Strachan</name>
    <location>London</location>
</employee>
```
while the actual content is:
```
<employee id="james">
    <name>
        <firstName>James</firstName>
        <lastName>Strachan</lastName>
    </name>
    <location>
        <city>London</city>
    </location>
</employee>
```

## Modifications:

* Refer the text content of the target elements instead of the elements
* Add a space character between the first name and the last name.

## Result:

The output file has now expected content. 
