### PR TITLE
CAMEL-11834: Add tests for servlet-tomcat/spring-security/spring-ws/spring-xquery/twitter-websocket/vertx-kafka/widget-gadget-java/widget-gadget-xml

### DIFF
--- a/examples/artemis-large-messages/src/test/java/org/apache/camel/example/ArtemisLargeMessageTest.java
+++ b/examples/artemis-large-messages/src/test/java/org/apache/camel/example/ArtemisLargeMessageTest.java
@@ -34,7 +34,7 @@ import java.io.RandomAccessFile;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.jgroups.util.Util.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test allowing to ensure that Camel and Artemis can both support large files that cannot fit
@@ -79,13 +79,12 @@ class ArtemisLargeMessageTest {
         NotifyBuilder notify = new NotifyBuilder(context).from("jms:queue:data").whenCompleted(1).create();
 
         assertTrue(
-            "The big file should be processed with success",
-            notify.matches(40, TimeUnit.SECONDS)
+            notify.matches(40, TimeUnit.SECONDS), "The big file should be processed with success"
         );
 
         assertTrue(
-            "The big file should be available in the target/outbox directory",
-            new File(String.format("target/outbox/%s", fileName)).exists()
+            new File(String.format("target/outbox/%s", fileName)).exists(),
+            "The big file should be available in the target/outbox directory"
         );
     }
 }

--- a/examples/artemis/README.adoc
+++ b/examples/artemis/README.adoc
@@ -64,7 +64,7 @@ example using the following command in a new shell:
 
 [source,sh]
 ----
-$ mvn compile exec:java
+$ mvn exec:java
 ----
 
 When the Camel application runs, you should see 2 orders being processed

--- a/examples/artemis/src/test/java/org/apache/camel/example/artemis/ArtemisTest.java
+++ b/examples/artemis/src/test/java/org/apache/camel/example/artemis/ArtemisTest.java
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.jgroups.util.Util.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that the Widget and Gadget use-case from the Enterprise Integration Patterns book works
@@ -79,8 +79,8 @@ class ArtemisTest extends CamelTestSupport {
                 .create();
 
         assertTrue(
-            "One order should be distributed to widget and and the other to gadget",
-            notify.matches(10, TimeUnit.SECONDS)
+            notify.matches(10, TimeUnit.SECONDS),
+            "One order should be distributed to widget and and the other to gadget"
         );
     }
 

--- a/examples/cxf-tomcat/src/test/resources/arquillian.xml
+++ b/examples/cxf-tomcat/src/test/resources/arquillian.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="tomcat" default="true">
+        <configuration>
+            <property name="tomcatHome">target/tomcat-embedded-9</property>
+            <property name="workDir">work</property>
+            <property name="bindHttpPort">8080</property>
+            <property name="unpackArchive">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -172,6 +172,7 @@
         <!-- Versions -->
         <arquillian-version>1.7.0.Alpha10</arquillian-version>
         <arquillian-tomcat-version>1.1.0.Final</arquillian-tomcat-version>
+        <arquillian-jetty-version>1.0.0.CR4</arquillian-jetty-version>
         <asciidoctorj-version>2.1.0</asciidoctorj-version>
         <cdi-api-1.2-version>1.2</cdi-api-1.2-version>
         <glassfish-jaxb-runtime-version>${jakarta-jaxb-version}</glassfish-jaxb-runtime-version>

--- a/examples/servlet-tomcat/README.adoc
+++ b/examples/servlet-tomcat/README.adoc
@@ -15,23 +15,11 @@ $ mvn package
 === Run
 
 To run the example deploy it in Apache Tomcat by copying the `+.war+` to
-the deploy folder of Apache Tomcat.
+the `webapps` folder of Apache Tomcat.
 
-And then hit this url from a webbrowser which has further instructions
+And then hit http://localhost:8080/camel-example-servlet-tomcat from a web browser which provides further instructions
 
-----
-http://localhost:8080/camel-example-servlet-tomcat
-----
-
-http://localhost:8080/camel-example-servlet-tomcat
-
-The servlet is located at
-
-----
-http://localhost:8080/camel-example-servlet-tomcat/camel/hello
-----
-
-http://localhost:8080/camel-example-servlet-tomcat/camel/hello
+The servlet is located at http://localhost:8080/camel-example-servlet-tomcat/camel/hello
 
 === Help and contributions
 

--- a/examples/servlet-tomcat/pom.xml
+++ b/examples/servlet-tomcat/pom.xml
@@ -92,7 +92,38 @@
             <version>${log4j2-version}</version>
             <scope>runtime</scope>
         </dependency>
-
+        <!-- Test dependencies BEGIN -->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-tomcat-embedded-9</artifactId>
+            <version>${arquillian-tomcat-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <version>${tomcat-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <version>${arquillian-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest-assured-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test dependencies END -->
     </dependencies>
 
     <build>
@@ -100,6 +131,18 @@
         <finalName>${project.artifactId}</finalName>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- allows running this example with mvn jetty:run -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>

--- a/examples/servlet-tomcat/src/main/resources/camel-config.xml
+++ b/examples/servlet-tomcat/src/main/resources/camel-config.xml
@@ -20,7 +20,6 @@
 <!-- START SNIPPET: e1 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation="
          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">

--- a/examples/servlet-tomcat/src/main/webapp/index.html
+++ b/examples/servlet-tomcat/src/main/webapp/index.html
@@ -27,10 +27,6 @@ This example shows how to use route messages in Apache Tomcat using servlets wit
 To get started click <a href="camel/hello">this link</a>.
 <br/>
 <br/>
-This example is documented at
-<a href="http://camel.apache.org/servlet-tomcat-example.html">servlet tomcat example</a>
-
-<br/>
 If you hit any problems please let us know on the
 <a href="http://camel.apache.org/discussion-forums.html">Camel Forums</a>
 <br/>

--- a/examples/servlet-tomcat/src/test/java/org/apache/camel/example/ServletTomcatIT.java
+++ b/examples/servlet-tomcat/src/test/java/org/apache/camel/example/ServletTomcatIT.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.net.URL;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * A basic integration test checking that Camel Servlet can be used with Apache Tomcat.
+ */
+@ExtendWith(ArquillianExtension.class)
+public class ServletTomcatIT {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        // build the .war with all the resources and libraries
+        return ShrinkWrap.create(WebArchive.class, "camel-example-servlet-tomcat.war")
+            .setWebXML(new File("./src/main/webapp/WEB-INF/web.xml"))
+            .addAsResource("log4j2.properties")
+            .addAsResource("camel-config.xml")
+            .addAsLibraries(
+                Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve()
+                    .withTransitivity().asFile()
+            );
+    }
+
+    @ArquillianResource
+    URL url;
+
+    @Test
+    @RunAsClient
+    void should_answer_without_the_name_parameter() {
+        given()
+            .baseUri(url.toString())
+        .when()
+            .get("/camel/hello")
+        .then()
+            .body(containsString("Add a name parameter to uri"));
+    }
+
+    @Test
+    @RunAsClient
+    void should_answer_with_the_name_parameter() {
+        given()
+            .baseUri(url.toString())
+        .when()
+            .queryParam("name", "foo")
+            .get("/camel/hello")
+        .then()
+            .body(containsString("Hello foo how are you today?"));
+    }
+}

--- a/examples/servlet-tomcat/src/test/resources/arquillian.xml
+++ b/examples/servlet-tomcat/src/test/resources/arquillian.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="tomcat" default="true">
+        <configuration>
+            <property name="tomcatHome">target/tomcat-embedded-9</property>
+            <property name="workDir">work</property>
+            <property name="bindHttpPort">8888</property>
+            <property name="unpackArchive">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/examples/splunk/README.adoc
+++ b/examples/splunk/README.adoc
@@ -28,7 +28,7 @@ $ mvn compile
 To run the random search client you type:
 
 ----
-$ mvn compile exec:java -Psearch-client
+$ mvn exec:java -Psearch-client
 ----
 
 … and response data will be printed on the console.
@@ -36,7 +36,7 @@ $ mvn compile exec:java -Psearch-client
 To run the saved search client you type:
 
 ----
-$ mvn compile exec:java -Psaved-search-client
+$ mvn exec:java -Psaved-search-client
 ----
 
 … and response data will be printed on the console.
@@ -44,7 +44,7 @@ $ mvn compile exec:java -Psaved-search-client
 To run the saved search client you type:
 
 ----
-$ mvn compile exec:java -Ppublish-event-client
+$ mvn exec:java -Ppublish-event-client
 ----
 
 … and logs will be printed on the console.

--- a/examples/spring-security/README.adoc
+++ b/examples/spring-security/README.adoc
@@ -10,7 +10,7 @@ camel endpoint.
 You will need to compile this example first:
 
 ----
-$ mvn clean install
+$ mvn clean package
 ----
 
 === Run
@@ -20,16 +20,17 @@ the application server
 
 The example consumes messages from a servlet endpoint which is secured
 by Spring Security with http basic authentication, there are two
-service:
-http://localhost:8080/camel-example-spring-security-${camel.version}/camel/user
-is for the authenticated user whose role is ROLE_USER
-http://localhost:8080/camel-example-spring-security-${camel.version}/camel/admin
-is for the authenticated user whose role is ROLE_ADMIN
+services:
+
+* http://localhost:8080/camel-example-spring-security/camel/user
+is for the authenticated user whose role is `ROLE_USER`
+* http://localhost:8080/camel-example-spring-security/camel/admin
+is for the authenticated user whose role is `ROLE_ADMIN`
 
 Then you can use the script in the client directory to send the request
-and check the response, or use browser to access upper urls with the
+and check the response, or use a web browser to access upper urls with the
 user/password (`+jim/jimspassword+` with the admin and user role or
-`+bob/bobspassword+` with user role).
+`+bob/bobspassword+` with the user role only).
 
 === Help and contributions
 

--- a/examples/spring-security/client/access-admin-as-bob.sh
+++ b/examples/spring-security/client/access-admin-as-bob.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-rm -rf work
-mkdir work
-POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --http-user=bob --http-password=bobspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/admin
-cat -n work/* | less
+WORK_DIR=../target/work
+rm -rf $WORK_DIR
+mkdir -p $WORK_DIR
+wget --http-user=bob --http-password=bobspassword --directory-prefix=$WORK_DIR  --output-file=$WORK_DIR/log.txt http://localhost:8080/camel-example-spring-security/camel/admin
+cat -n $WORK_DIR/* | less

--- a/examples/spring-security/client/access-admin-as-jim.sh
+++ b/examples/spring-security/client/access-admin-as-jim.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-rm -rf work
-mkdir work
-POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --http-user=jim --http-password=jimspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/admin
-cat -n work/* | less
+WORK_DIR=../target/work
+rm -rf $WORK_DIR
+mkdir -p $WORK_DIR
+wget --http-user=jim --http-password=jimspassword --directory-prefix=$WORK_DIR  --output-file=$WORK_DIR/log.txt http://localhost:8080/camel-example-spring-security/camel/admin
+cat -n $WORK_DIR/* | less

--- a/examples/spring-security/client/access-admin-no-auth.sh
+++ b/examples/spring-security/client/access-admin-no-auth.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-rm -rf work
-mkdir work
-POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/admin
-cat -n work/* | less
+WORK_DIR=../target/work
+rm -rf $WORK_DIR
+mkdir -p $WORK_DIR
+wget --directory-prefix=$WORK_DIR  --output-file=$WORK_DIR/log.txt http://localhost:8080/camel-example-spring-security/camel/admin
+cat -n $WORK_DIR/* | less

--- a/examples/spring-security/client/access-user-as-bob.sh
+++ b/examples/spring-security/client/access-user-as-bob.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-rm -rf work
-mkdir work
-POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --http-user=bob --http-password=bobspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/user
-cat -n work/* | less
+WORK_DIR=../target/work
+rm -rf $WORK_DIR
+mkdir -p $WORK_DIR
+wget --http-user=bob --http-password=bobspassword --directory-prefix=$WORK_DIR  --output-file=$WORK_DIR/log.txt http://localhost:8080/camel-example-spring-security/camel/user
+cat -n $WORK_DIR/* | less

--- a/examples/spring-security/client/access-user-as-jim.sh
+++ b/examples/spring-security/client/access-user-as-jim.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-rm -rf work
-mkdir work
-POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --http-user=jim --http-password=jimspassword --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/user
-cat -n work/* | less
+WORK_DIR=../target/work
+rm -rf $WORK_DIR
+mkdir -p $WORK_DIR
+wget --http-user=jim --http-password=jimspassword --directory-prefix=$WORK_DIR  --output-file=$WORK_DIR/log.txt http://localhost:8080/camel-example-spring-security/camel/user
+cat -n $WORK_DIR/* | less

--- a/examples/spring-security/client/access-user-no-auth.sh
+++ b/examples/spring-security/client/access-user-no-auth.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-rm -rf work
-mkdir work
-POM_VERSION=$(../../../mvnw -f ../pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
-wget --directory-prefix=work  --output-file=work/log.txt http://localhost:8080/camel-example-spring-security-$POM_VERSION/camel/user
-cat -n work/* | less
+WORK_DIR=../target/work
+rm -rf $WORK_DIR
+mkdir -p $WORK_DIR
+wget --directory-prefix=$WORK_DIR  --output-file=$WORK_DIR/log.txt http://localhost:8080/camel-example-spring-security/camel/user
+cat -n $WORK_DIR/* | less

--- a/examples/spring-security/pom.xml
+++ b/examples/spring-security/pom.xml
@@ -97,14 +97,56 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- for testing -->
+        <!-- Test dependencies BEGIN -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-tomcat-embedded-9</artifactId>
+            <version>${arquillian-tomcat-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <version>${tomcat-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <version>${arquillian-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest-assured-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test dependencies END -->
 
     </dependencies>
 
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/spring-security/src/test/java/org/apache/camel/example/SpringSecurityIT.java
+++ b/examples/spring-security/src/test/java/org/apache/camel/example/SpringSecurityIT.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.net.URL;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * A basic integration test checking that Camel can leverage Spring Security to secure the endpoints.
+ */
+@ExtendWith(ArquillianExtension.class)
+public class SpringSecurityIT {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        // build the .war with all the resources and libraries
+        return ShrinkWrap.create(WebArchive.class, "camel-example-spring-security.war")
+            .setWebXML(new File("./src/main/webapp/WEB-INF/web.xml"))
+            .addAsResource("log4j2.properties")
+            .addAsResource("camel-context.xml")
+            .addAsLibraries(
+                Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve()
+                    .withTransitivity().asFile()
+            );
+    }
+
+    @ArquillianResource
+    URL url;
+
+    @Test
+    @RunAsClient
+    void should_prevent_anonymous_access_to_admin() {
+        given()
+            .baseUri(url.toString())
+        .when()
+            .get("/camel/admin")
+        .then()
+            .statusCode(401);
+    }
+
+    @Test
+    @RunAsClient
+    void should_prevent_bob_to_access_to_admin() {
+        given()
+            .baseUri(url.toString())
+            .auth().basic("bob", "bobspassword")
+        .when()
+            .get("/camel/admin")
+        .then()
+            .body(containsString("Access Denied with the Policy"));
+    }
+
+    @Test
+    @RunAsClient
+    void should_allow_jim_to_access_to_admin() {
+        given()
+            .baseUri(url.toString())
+            .auth().basic("jim", "jimspassword")
+        .when()
+            .get("/camel/admin")
+        .then()
+            .statusCode(200)
+            .body(containsString("OK"));
+    }
+
+    @Test
+    @RunAsClient
+    void should_prevent_anonymous_access_to_user() {
+        given()
+            .baseUri(url.toString())
+        .when()
+            .get("/camel/user")
+        .then()
+            .statusCode(401);
+    }
+
+    @Test
+    @RunAsClient
+    void should_allow_bob_to_access_to_user() {
+        given()
+            .baseUri(url.toString())
+            .auth().basic("bob", "bobspassword")
+        .when()
+            .get("/camel/user")
+        .then()
+            .statusCode(200)
+            .body(containsString("Normal user"));
+    }
+
+    @Test
+    @RunAsClient
+    void should_allow_jim_to_access_to_user() {
+        given()
+            .baseUri(url.toString())
+            .auth().basic("jim", "jimspassword")
+        .when()
+            .get("/camel/user")
+        .then()
+            .statusCode(200)
+            .body(containsString("Normal user"));
+    }
+
+}

--- a/examples/spring-security/src/test/resources/arquillian.xml
+++ b/examples/spring-security/src/test/resources/arquillian.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="tomcat" default="true">
+        <configuration>
+            <property name="tomcatHome">target/tomcat-embedded-9</property>
+            <property name="workDir">work</property>
+            <property name="bindHttpPort">8888</property>
+            <property name="unpackArchive">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/examples/spring-ws/README.adoc
+++ b/examples/spring-ws/README.adoc
@@ -10,7 +10,7 @@ and Spring Web Services.
 You will need to compile this example first:
 
 ----
-$ mvn clean install
+$ mvn clean package
 ----
 
 === Run
@@ -23,9 +23,9 @@ $ mvn jetty:run
 
 To stop the server hit ctrl+c
 
-The web service endpoint address is: http://localhost:8080/increment
+The web service endpoint address is http://localhost:8080/increment
 
-The WSDL is available at: http://localhost:8080/increment/increment.wsdl
+The WSDL is available at http://localhost:8080/increment/increment.wsdl
 
 You can test the web service using for example SOAP-UI. This excellent
 tool is freely available from http://www.soapui.org. There’s a ready to

--- a/examples/spring-ws/pom.xml
+++ b/examples/spring-ws/pom.xml
@@ -74,7 +74,24 @@
             <artifactId>wsdl4j</artifactId>
             <version>${wsdl4j-version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>${jaxws-api-version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+            <version>1.3.28</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>javax.xml.soap-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <!-- logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -107,19 +124,75 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- for testing -->
+        <!-- Test dependencies BEGIN -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-jetty-embedded-9</artifactId>
+            <version>${arquillian-jetty-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${shrinkwrap-resolver-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>${jetty-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-deploy</artifactId>
+            <version>${jetty-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- Jetty annotations needed for Servlet 3.1 support -->
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-annotations</artifactId>
+            <version>${jetty-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <version>${arquillian-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest-assured-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test dependencies END -->
 
     </dependencies>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Allows the routes to be run via 'mvn camel:run' -->
             <plugin>
                 <groupId>org.apache.camel</groupId>
@@ -144,34 +217,4 @@
         </plugins>
 
     </build>
-    <profiles>
-      <profile>
-            <id>jdk9s-build</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-        
-            <dependencies>
-                <dependency>
-                    <groupId>javax.xml.ws</groupId>
-                    <artifactId>jaxws-api</artifactId>
-                    <version>2.3.0</version>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.sun.xml.messaging.saaj</groupId>
-                    <artifactId>saaj-impl</artifactId>
-                    <version>1.3.28</version>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>javax.xml.soap</groupId>
-                            <artifactId>javax.xml.soap-api</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
-        </profile>
-      </profiles>
-
 </project>

--- a/examples/spring-ws/src/main/java/org/apache/camel/example/server/IncrementRoute.java
+++ b/examples/spring-ws/src/main/java/org/apache/camel/example/server/IncrementRoute.java
@@ -42,7 +42,7 @@ public class IncrementRoute extends RouteBuilder {
             IncrementResponse response = new IncrementResponse();
             int result = request.getInput() + 1; // increment input value
             response.setResult(result); 
-            exchange.getOut().setBody(response);
+            exchange.getIn().setBody(response);
         }
     }
    

--- a/examples/spring-ws/src/main/java/org/apache/camel/example/server/model/IncrementRequest.java
+++ b/examples/spring-ws/src/main/java/org/apache/camel/example/server/model/IncrementRequest.java
@@ -32,7 +32,7 @@ public class IncrementRequest {
         return input;
     }
 
-    public void setInpu(int input) {
+    public void setInput(int input) {
         this.input = input;
     }
 }

--- a/examples/spring-ws/src/test/java/org/apache/camel/example/server/SpringWSIT.java
+++ b/examples/spring-ws/src/test/java/org/apache/camel/example/server/SpringWSIT.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.server;
+
+import io.restassured.RestAssured;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.net.URL;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.XmlConfig.xmlConfig;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * A basic integration test checking that Camel can leverage Spring Web Services to expose a Web Service.
+ */
+@ExtendWith(ArquillianExtension.class)
+public class SpringWSIT {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        // build the .war with all the resources and libraries
+        return ShrinkWrap.create(WebArchive.class, "camel-example-spring-ws.war")
+            .setWebXML(new File("./src/main/webapp/WEB-INF/web.xml"))
+            .addAsWebInfResource(new File("./src/main/webapp/WEB-INF/increment.xsd"))
+            .addAsWebInfResource(new File("./src/main/webapp/WEB-INF/spring-ws-servlet.xml"))
+            .addAsResource("log4j2.properties")
+            .addAsResource("org/apache/camel/example/server/model/jaxb.index")
+            .addAsLibraries(
+                Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve()
+                    .withTransitivity().asFile()
+            );
+    }
+
+    @ArquillianResource
+    URL url;
+
+    @Test
+    @RunAsClient
+    void should_call_the_web_service() {
+        given()
+            .config(
+                RestAssured.config().xmlConfig(
+                    xmlConfig().declareNamespace("soapenv", "http://schemas.xmlsoap.org/soap/envelope/")
+                        .declareNamespace("inc", "http://camel.apache.org/example/increment")
+                )
+            )
+            .baseUri(url.toString())
+        .when()
+            .body("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:inc=\"http://camel.apache.org/example/increment\">\n" +
+                    "   <soapenv:Header/>\n" +
+                    "   <soapenv:Body>\n" +
+                    "      <inc:incrementRequest>\n" +
+                    "         <inc:input>90</inc:input>\n" +
+                    "      </inc:incrementRequest>\n" +
+                    "   </soapenv:Body>\n" +
+                    "</soapenv:Envelope>")
+            .contentType("text/xml")
+            .post("/increment")
+        .then()
+            .statusCode(200)
+            .body("soapenv:Envelope.soapenv:Body.inc:incrementResponse.inc:result.text()", equalTo("91"));
+
+    }
+
+    @Test
+    @RunAsClient
+    void should_access_to_the_wsdl() {
+        given()
+            .baseUri(url.toString())
+        .when()
+            .get("/increment/increment.wsdl")
+        .then()
+            .statusCode(200)
+            .contentType(is("text/xml"))
+            .body(containsString("http://localhost"));
+    }
+
+}

--- a/examples/spring-ws/src/test/resources/arquillian.xml
+++ b/examples/spring-ws/src/test/resources/arquillian.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jetty" default="true">
+        <configuration>
+            <property name="bindHttpPort">8888</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/examples/spring-xquery/pom.xml
+++ b/examples/spring-xquery/pom.xml
@@ -116,9 +116,8 @@
 
         <!-- for testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/examples/spring-xquery/src/test/java/org/apache/camel/example/SpringXQueryTest.java
+++ b/examples/spring-xquery/src/test/java/org/apache/camel/example/SpringXQueryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.junit5.CamelSpringTest;
+import org.apache.camel.test.spring.junit5.MockEndpoints;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * A unit test allowing to check that Camel can transform messages using XQuery.
+ */
+@CamelSpringTest
+@ContextConfiguration("/META-INF/spring/camelContext.xml")
+@MockEndpoints("file:target/outputFiles")
+class SpringXQueryTest {
+
+    @EndpointInject("mock:file:target/outputFiles")
+    MockEndpoint result;
+
+    @Test
+    void should_transform_messages_with_xquery() throws Exception {
+
+        result.expectedBodiesReceived("<employee id=\"james\"><name>James Strachan</name><location>London</location></employee>");
+        result.expectedMessageCount(1);
+
+        result.assertIsSatisfied();
+    }
+}

--- a/examples/transformer-demo/src/main/java/org/apache/camel/example/transformer/demo/OrderProcessor.java
+++ b/examples/transformer-demo/src/main/java/org/apache/camel/example/transformer/demo/OrderProcessor.java
@@ -32,6 +32,6 @@ public class OrderProcessor implements Processor {
             .setAccepted(true)
             .setOrderId(order.getOrderId())
             .setDescription(String.format("Order accepted:[item='%s' quantity='%s']", order.getItemId(), order.getQuantity()));
-        exchange.getOut().setBody(answer);
+        exchange.getIn().setBody(answer);
     }
 }

--- a/examples/transformer-demo/src/main/java/org/apache/camel/example/transformer/demo/client/CamelClient.java
+++ b/examples/transformer-demo/src/main/java/org/apache/camel/example/transformer/demo/client/CamelClient.java
@@ -16,9 +16,10 @@
  */
 package org.apache.camel.example.transformer.demo.client;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -29,6 +30,7 @@ import org.apache.camel.spi.DataType;
 import org.apache.camel.spi.DataTypeAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
@@ -51,58 +53,44 @@ public final class CamelClient {
         
         // START SNIPPET: e1
         LOG.info("---> Starting 'order' camel route...");
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("META-INF/spring/camel-context.xml");
-        context.start();
-        CamelContext camelContext = context.getBean("order", CamelContext.class);
-        ProducerTemplate producer = camelContext.createProducerTemplate();
-        // END SNIPPET: e1
-        Thread.sleep(1000);
-        
-        Order order = new Order()
-            .setOrderId("Order-Java-0001")
-            .setItemId("MILK")
-            .setQuantity(3);
-        LOG.info("---> Sending '{}' to 'direct:java'", order);
-        OrderResponse response = producer.requestBody("direct:java", order, OrderResponse.class);
-        Thread.sleep(1000);
-        LOG.info("---> Received '{}'", response);
-        LOG.info("---> CSV log now contains:{}", getCsvLog());
-        Thread.sleep(1000);
-        
-        String orderXml = "<order orderId=\"Order-XML-0001\" itemId=\"MIKAN\" quantity=\"365\"/>";
-        LOG.info("---> Sending '{}' to 'direct:xml'", orderXml);
-        Exchange answerXml = producer.send("direct:xml", ex -> {
-            ((DataTypeAware)ex.getIn()).setBody(orderXml, new DataType("xml:XMLOrder"));
-        });
-        Thread.sleep(1000);
-        LOG.info("---> Received '{}'", answerXml.getOut().getBody(String.class));
-        LOG.info("---> CSV log now contains:{}", getCsvLog());
-        Thread.sleep(1000);
-        
-        String orderJson = "{\"orderId\":\"Order-JSON-0001\", \"itemId\":\"MIZUYO-KAN\", \"quantity\":\"16350\"}";
-        LOG.info("---> Sending '{}' to 'direct:json'", orderJson);
-        Exchange answerJson = producer.send("direct:json", ex -> {
-            ((DataTypeAware)ex.getIn()).setBody(orderJson, new DataType("json"));
-        });
-        Thread.sleep(1000);
-        LOG.info("---> Received '{}'", answerJson.getOut().getBody(String.class));
-        LOG.info("---> CSV log now contains:{}", getCsvLog());
-        Thread.sleep(1000);
-        
-        context.stop();
+        try (ConfigurableApplicationContext context = new ClassPathXmlApplicationContext("META-INF/spring/camel-context.xml")) {
+            context.start();
+            CamelContext camelContext = context.getBean("order", CamelContext.class);
+            try (ProducerTemplate producer = camelContext.createProducerTemplate()) {
+                // END SNIPPET: e1
+                Thread.sleep(1000);
+
+                Order order = new Order()
+                        .setOrderId("Order-Java-0001")
+                        .setItemId("MILK")
+                        .setQuantity(3);
+                LOG.info("---> Sending '{}' to 'direct:java'", order);
+                OrderResponse response = producer.requestBody("direct:java", order, OrderResponse.class);
+                logResponse(response);
+
+                String orderXml = "<order orderId=\"Order-XML-0001\" itemId=\"MIKAN\" quantity=\"365\"/>";
+                LOG.info("---> Sending '{}' to 'direct:xml'", orderXml);
+                Exchange answerXml = producer.send("direct:xml",
+                    ex -> ((DataTypeAware) ex.getIn()).setBody(orderXml, new DataType("xml:XMLOrder"))
+                );
+                logResponse(answerXml.getIn().getBody(String.class));
+
+                String orderJson = "{\"orderId\":\"Order-JSON-0001\", \"itemId\":\"MIZUYO-KAN\", \"quantity\":\"16350\"}";
+                LOG.info("---> Sending '{}' to 'direct:json'", orderJson);
+                Exchange answerJson = producer.send("direct:json", ex -> ((DataTypeAware) ex.getIn()).setBody(orderJson, new DataType("json")));
+                logResponse(answerJson.getIn().getBody(String.class));
+            }
+        }
     }
 
-    public static String getCsvLog() throws Exception {
-        BufferedReader reader = new BufferedReader(new FileReader(new File(CSV_PATH)));
-        try {
-            StringBuilder buf = new StringBuilder();
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                buf.append(System.lineSeparator()).append(line);
-            }
-            return buf.toString();
-        } finally {
-            reader.close();
-        }
+    private static void logResponse(Object response) throws Exception {
+        Thread.sleep(1000);
+        LOG.info("---> Received '{}'", response);
+        LOG.info("---> CSV log now contains:\n{}", getCsvLog());
+        Thread.sleep(1000);
+    }
+
+    public static String getCsvLog() throws IOException {
+        return Files.readString(Paths.get(CSV_PATH));
     }
 }

--- a/examples/transformer-demo/src/main/resources/META-INF/spring/camel-context.xml
+++ b/examples/transformer-demo/src/main/resources/META-INF/spring/camel-context.xml
@@ -19,11 +19,9 @@
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
        xmlns:camel="http://camel.apache.org/schema/spring"
        xsi:schemaLocation="
          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
     <!-- START SNIPPET: e1 -->

--- a/examples/twitter-websocket/README.adoc
+++ b/examples/twitter-websocket/README.adoc
@@ -2,16 +2,16 @@
 
 === Introduction
 
-The example is demonstrating how to poll a constant feed of twitter
+The example is demonstrating how to poll a constant feed of Twitter
 searches and publish results in real time using web socket to a web
 page.
 
-This example is already configured using a testing purpose twitter
+This example is already configured using a testing purpose Twitter
 account named `cameltweet'. And therefore the example is ready to run
 out of the box.
 
 This account is only for testing purpose, and should not be used in your
-custom applications. For that you need to setup and use your own twitter
+custom applications. For that you need to set up and use your own Twitter
 account.
 
 === Build

--- a/examples/twitter-websocket/pom.xml
+++ b/examples/twitter-websocket/pom.xml
@@ -87,7 +87,19 @@
             <version>${log4j2-version}</version>
             <scope>runtime</scope>
         </dependency>
-
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+            <!-- 2.0.17 onwards has TSL/SSL problems -->
+            <version>2.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
+++ b/examples/twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
@@ -29,11 +29,11 @@ public final class CamelTwitterWebSocketMain {
     // Finally, generate your access token and secret.
 
     // This uses the Twitter 'cameltweet' account for testing purposes.
-    // do NOT use this twitter account in your applications!
-    private static String consumerKey = "NMqaca1bzXsOcZhP2XlwA";
-    private static String consumerSecret = "VxNQiRLwwKVD0K9mmfxlTTbVdgRpriORypnUbHhxeQw";
-    private static String accessToken = "26693234-W0YjxL9cMJrC0VZZ4xdgFMymxIQ10LeL1K8YlbBY";
-    private static String accessTokenSecret = "BZD51BgzbOdFstWZYsqB5p5dbuuDV12vrOdatzhY4E";
+    // do NOT use this Twitter account in your applications!
+    private static final String consumerKey = "NMqaca1bzXsOcZhP2XlwA";
+    private static final String consumerSecret = "VxNQiRLwwKVD0K9mmfxlTTbVdgRpriORypnUbHhxeQw";
+    private static final String accessToken = "26693234-W0YjxL9cMJrC0VZZ4xdgFMymxIQ10LeL1K8YlbBY";
+    private static final String accessTokenSecret = "BZD51BgzbOdFstWZYsqB5p5dbuuDV12vrOdatzhY4E";
 
     private CamelTwitterWebSocketMain() {
         // to pass checkstyle we have a private constructor
@@ -50,6 +50,16 @@ public final class CamelTwitterWebSocketMain {
         // create a new Camel Main so we can easily start Camel
         Main main = new Main();
 
+        TwitterWebSocketRoute route = createTwitterWebSocketRoute("gaga", 6_000);
+
+        // add our routes to Camel
+        main.configure().addRoutesBuilder(route);
+
+        // and run, which keeps blocking until we terminate the JVM (or stop CamelContext)
+        main.run();
+    }
+
+    static TwitterWebSocketRoute createTwitterWebSocketRoute(String searchTerm, int delay) {
         TwitterWebSocketRoute route = new TwitterWebSocketRoute();
 
         // setup twitter application authentication
@@ -61,17 +71,12 @@ public final class CamelTwitterWebSocketMain {
         // poll for gaga, every 5nd second
         // twitter rate limits 180 per 15 min, so that is 0.2/sec, eg 1/5sec.
         // so to be safe we do 6 seconds
-        route.setSearchTerm("gaga");
-        route.setDelay(6000);
+        route.setSearchTerm(searchTerm);
+        route.setDelay(delay);
 
         // web socket on port 9090
         route.setPort(9090);
-
-        // add our routes to Camel
-        main.configure().addRoutesBuilder(route);
-
-        // and run, which keeps blocking until we terminate the JVM (or stop CamelContext)
-        main.run();
+        return route;
     }
 
 }

--- a/examples/twitter-websocket/src/test/java/org/apache/camel/example/websocket/CamelTwitterWebSocketTest.java
+++ b/examples/twitter-websocket/src/test/java/org/apache/camel/example/websocket/CamelTwitterWebSocketTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.websocket;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.asynchttpclient.ws.WebSocket;
+import org.asynchttpclient.ws.WebSocketListener;
+import org.asynchttpclient.ws.WebSocketUpgradeHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.camel.example.websocket.CamelTwitterWebSocketMain.createTwitterWebSocketRoute;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A unit test checking that Camel can poll a constant feed of Twitter and publish results using WebSocket.
+ */
+class CamelTwitterWebSocketTest extends CamelTestSupport {
+
+    @Test
+    void should_support_polling_twitter_publishing_websocket() throws Exception {
+        try (AsyncHttpClient c = new DefaultAsyncHttpClient()) {
+            final CountDownLatch received = new CountDownLatch(1);
+            WebSocket websocket = null;
+            try {
+                websocket = c.prepareGet("ws://localhost:9090/camel-tweet")
+                        .execute(new WebSocketUpgradeHandler.Builder().addWebSocketListener(
+                                new WebSocketListener() {
+
+                                    @Override
+                                    public void onOpen(WebSocket websocket) {
+                                    }
+
+                                    @Override
+                                    public void onClose(WebSocket websocket, int code, String reason) {
+
+                                    }
+
+                                    @Override
+                                    public void onTextFrame(String payload, boolean finalFragment, int rsv) {
+                                        received.countDown();
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                    }
+                                }).build()).get();
+                assertTrue(received.await(30, TimeUnit.SECONDS));
+            } finally {
+                if (websocket != null) {
+                    websocket.sendCloseFrame();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() {
+        return createTwitterWebSocketRoute("test", 100);
+    }
+}

--- a/examples/vertx-kafka/README.adoc
+++ b/examples/vertx-kafka/README.adoc
@@ -15,14 +15,16 @@ This project consists of the following examples:
 The easiest way to get Kafka up and running for _dev_ environment, is to use Confluent Local Community setup, you can set it up using the instructions https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart[here].
 
 Once you have done with the setup, start Kafka using this command:
-```
-confluent local services start
-```
+
+----
+$ confluent local services start
+----
 
 When you are done from the example, you can stop kafka with this command:
-```
-confluent local services stop
-```
+
+----
+$ confluent local services stop
+----
 
 We don't need to create the topics here as the Confluent dev environment configured to create topics automatically once the producer has started to produce messages to Kafka.
 
@@ -30,17 +32,23 @@ We don't need to create the topics here as the Confluent dev environment configu
 
 You will need to compile this example first:
 
-    $ mvn compile
+----
+$ mvn compile
+----
 
 === Run
 
-Run the consumer first in separate shell 
+Run the consumer first in separate shell
 
-    $ mvn compile exec:java -Pkafka-consumer
+----
+$ mvn exec:java -Pkafka-consumer
+----
 
-Run the message producer in the seperate shell
+Run the message producer in the separate shell
 
-    $ mvn compile exec:java -Pkafka-producer
+----
+$ mvn exec:java -Pkafka-producer
+----
 
 Initially, some messages are sent programmatically. 
 On the command prompt, type the messages. Each line is sent as one message to kafka

--- a/examples/vertx-kafka/pom.xml
+++ b/examples/vertx-kafka/pom.xml
@@ -92,6 +92,18 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j2-version}</version>
         </dependency>
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/examples/vertx-kafka/src/main/java/org/apache/camel/example/vertx/kafka/MessagePublisherClient.java
+++ b/examples/vertx-kafka/src/main/java/org/apache/camel/example/vertx/kafka/MessagePublisherClient.java
@@ -20,21 +20,22 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.builder.component.ComponentsBuilderFactory;
 import org.apache.camel.component.vertx.kafka.VertxKafkaConstants;
-import org.apache.camel.main.Main;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class MessagePublisherClient {
-    
-    private static final Logger LOG = LoggerFactory.getLogger(MessagePublisherClient.class);
 
-    // use Camel Main to setup and run Camel
-    private static Main main = new Main();
-    
+    private static final Logger LOG = LoggerFactory.getLogger(MessagePublisherClient.class);
+    public static final String DIRECT_KAFKA_START = "direct:kafkaStart";
+    public static final String DIRECT_KAFKA_START_WITH_PARTITIONER = "direct:kafkaStartWithPartitioner";
+    public static final String HEADERS = "${headers}";
+
     private MessagePublisherClient() { }
 
     public static void main(String[] args) throws Exception {
@@ -42,74 +43,76 @@ public final class MessagePublisherClient {
         LOG.info("About to run Camel Vertx Kafka integration...");
 
         String testKafkaMessage = "Test Message from  MessagePublisherClient " + Calendar.getInstance().getTime();
+        try (CamelContext camelContext = new DefaultCamelContext()) {
+            // Set the location of the configuration
+            camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
+            // Set up the Kafka component
+            setUpKafkaComponent(camelContext);
+            // Add route to send messages to Kafka
+            camelContext.addRoutes(createRouteBuilder());
 
-        // add routes
-        main.configure().addRoutesBuilder(new RouteBuilder() {
-            @Override public void configure() throws Exception {
+            try (ProducerTemplate producerTemplate = camelContext.createProducerTemplate()) {
+                camelContext.start();
 
-                // setup kafka component with the brokers using component DSL
-                ComponentsBuilderFactory.vertxKafka()
-                        .bootstrapServers("{{kafka.host}}:{{kafka.port}}")
-                        .register(main.getCamelContext(), "vertx-kafka");
+                Map<String, Object> headers = new HashMap<>();
 
-                from("direct:kafkaStart").routeId("DirectToKafka")
-                        .to("vertx-kafka:{{producer.topic}}").log("${headers}");
+                headers.put(VertxKafkaConstants.PARTITION_ID, 0);
+                headers.put(VertxKafkaConstants.MESSAGE_KEY, "1");
+                producerTemplate.sendBodyAndHeaders(DIRECT_KAFKA_START, testKafkaMessage, headers);
+
+                // Send with topicName in header
+
+                testKafkaMessage = "TOPIC " + testKafkaMessage;
+                headers.put(VertxKafkaConstants.MESSAGE_KEY, "2");
+                headers.put(VertxKafkaConstants.TOPIC, "TestLog");
+
+                producerTemplate.sendBodyAndHeaders("direct:kafkaStartNoTopic", testKafkaMessage, headers);
+
+                testKafkaMessage = "PART 0 :  " + testKafkaMessage;
+                Map<String, Object> newHeader = new HashMap<>();
+                newHeader.put(VertxKafkaConstants.MESSAGE_KEY, "AB"); // This should go to partition 0
+
+                producerTemplate.sendBodyAndHeaders(DIRECT_KAFKA_START_WITH_PARTITIONER, testKafkaMessage, newHeader);
+            }
+
+            LOG.info("Successfully published event to Kafka.");
+            System.out.println("Enter text on the line below : [Press Ctrl-C to exit.] ");
+
+            Thread.sleep(5L * 60 * 1_000);
+        }
+    }
+
+    static RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            public void configure() {
+                from(DIRECT_KAFKA_START).routeId("DirectToKafka")
+                        .to("vertx-kafka:{{producer.topic}}").log(HEADERS);
 
                 // Topic can be set in header as well.
 
                 from("direct:kafkaStartNoTopic").routeId("kafkaStartNoTopic")
                         .to("vertx-kafka:dummy")
-                        .log("${headers}");
+                        .log(HEADERS);
 
                 // Use custom partitioner based on the key.
 
-                from("direct:kafkaStartWithPartitioner").routeId("kafkaStartWithPartitioner")
+                from(DIRECT_KAFKA_START_WITH_PARTITIONER).routeId("kafkaStartWithPartitioner")
                         .to("vertx-kafka:{{producer.topic}}?partitionerClass={{producer.partitioner}}")
-                        .log("${headers}");
+                        .log(HEADERS);
 
 
                 // Takes input from the command line.
 
-                from("stream:in").setHeader(VertxKafkaConstants.PARTITION_ID, simple("0"))
-                        .setHeader(VertxKafkaConstants.MESSAGE_KEY, simple("1")).to("direct:kafkaStart");
+                from("stream:in").id("input").setHeader(VertxKafkaConstants.PARTITION_ID, simple("0"))
+                        .setHeader(VertxKafkaConstants.MESSAGE_KEY, simple("1")).to(DIRECT_KAFKA_START);
             }
-        });
+        };
+    }
 
-        // start and run Camel (block)
-        main.run();
-
-        ProducerTemplate producerTemplate = main.getCamelContext().createProducerTemplate();
-
-        Map<String, Object> headers = new HashMap<>();
-
-        headers.put(VertxKafkaConstants.PARTITION_ID, 0);
-        headers.put(VertxKafkaConstants.MESSAGE_KEY, "1");
-        producerTemplate.sendBodyAndHeaders("direct:kafkaStart", testKafkaMessage, headers);
-
-        // Send with topicName in header
-
-        testKafkaMessage = "TOPIC " + testKafkaMessage;
-        headers.put(VertxKafkaConstants.MESSAGE_KEY, "2");
-        headers.put(VertxKafkaConstants.TOPIC, "TestLog");
-
-        producerTemplate.sendBodyAndHeaders("direct:kafkaStartNoTopic", testKafkaMessage, headers);
-
-        testKafkaMessage = "PART 0 :  " + testKafkaMessage;
-        Map<String, Object> newHeader = new HashMap<>();
-        newHeader.put(VertxKafkaConstants.MESSAGE_KEY, "AB"); // This should go to partition 0
-
-        producerTemplate.sendBodyAndHeaders("direct:kafkaStartWithPartitioner", testKafkaMessage, newHeader);
-
-        testKafkaMessage = "PART 1 :  " + testKafkaMessage;
-        newHeader.put(VertxKafkaConstants.MESSAGE_KEY, "ABC"); // This should go to partition 1
-
-        producerTemplate.sendBodyAndHeaders("direct:kafkaStartWithPartitioner", testKafkaMessage, newHeader);
-
-        LOG.info("Successfully published event to Kafka.");
-        System.out.println("Enter text on the line below : [Press Ctrl-C to exit.] ");
-
-        Thread.sleep(5 * 60 * 1000);
-
-        main.stop();
+    static void setUpKafkaComponent(CamelContext camelContext) {
+        // setup kafka component with the brokers using component DSL
+        ComponentsBuilderFactory.vertxKafka()
+                .bootstrapServers("{{kafka.host}}:{{kafka.port}}")
+                .register(camelContext, "vertx-kafka");
     }
 }

--- a/examples/vertx-kafka/src/main/resources/application.properties
+++ b/examples/vertx-kafka/src/main/resources/application.properties
@@ -26,7 +26,7 @@ producer.partitioner=org.apache.camel.example.vertx.kafka.StringPartitioner
 
 # Consumer properties 
 
-# One consumer can listen to more than one topics.[ TestLog,AccessLog ] 
+# One consumer can listen to more than one topic.[ TestLog,AccessLog ]
 consumer.topic=TestLog
 consumer.group=kafkaGroup
 consumer.maxPollRecords=5000

--- a/examples/vertx-kafka/src/test/java/org/apache/camel/example/vertx/kafka/VertxKafkaTest.java
+++ b/examples/vertx-kafka/src/test/java/org/apache/camel/example/vertx/kafka/VertxKafkaTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.vertx.kafka;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.camel.example.vertx.kafka.MessagePublisherClient.setUpKafkaComponent;
+import static org.apache.camel.util.PropertiesHelper.asProperties;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A unit test checking that Camel can produce and consume messages to / from a Kafka broker using the Kafka Vertx
+ * component.
+ */
+class VertxKafkaTest extends CamelTestSupport {
+
+    private static final String IMAGE = "confluentinc/cp-kafka:6.2.2";
+    private static KafkaContainer CONTAINER;
+
+    @BeforeAll
+    static void init() {
+        CONTAINER = new KafkaContainer(DockerImageName.parse(IMAGE));
+        CONTAINER.start();
+    }
+
+    @AfterAll
+    static void destroy() {
+        if (CONTAINER != null) {
+            CONTAINER.stop();
+        }
+    }
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        // Set the location of the configuration
+        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
+        // Override the host and port of the broker
+        camelContext.getPropertiesComponent().setOverrideProperties(
+            asProperties(
+                "kafka.host", CONTAINER.getHost(),
+                "kafka.port", Integer.toString(CONTAINER.getMappedPort(9093))
+            )
+        );
+        setUpKafkaComponent(camelContext);
+        return camelContext;
+    }
+
+    @Test
+    void should_exchange_messages_with_a_kafka_broker() throws Exception {
+        // Replace the from endpoint to send messages easily
+        AdviceWith.adviceWith(context, "input", ad -> ad.replaceFromWith("direct:in"));
+
+        // must start Camel after we are done using advice-with
+        context.start();
+
+        String message = UUID.randomUUID().toString();
+        template.sendBody("direct:in", message);
+        NotifyBuilder notify = new NotifyBuilder(context).fromRoute("FromKafka")
+                .whenCompleted(1).whenBodiesReceived(message).create();
+        assertTrue(
+            notify.matches(20, TimeUnit.SECONDS), "1 message should be completed"
+        );
+    }
+
+    @Override
+    protected RoutesBuilder[] createRouteBuilders() {
+        return new RoutesBuilder[]{
+            MessageConsumerClient.createRouteBuilder(), MessagePublisherClient.createRouteBuilder()
+        };
+    }
+}

--- a/examples/widget-gadget-java/README.adoc
+++ b/examples/widget-gadget-java/README.adoc
@@ -24,26 +24,28 @@ _application server_ but just a plain old _Java Main_.
 You will need to build this example first:
 
 ----
-$ mvn install
+$ mvn compile
 ----
 
 === Run
 
 This example requires an existing Apache ActiveMQ broker running.
 
-To setup and run Apache ActiveMQ then download it from the
+To set up and run Apache ActiveMQ, download it from the
 http://activemq.apache.org/[ActiveMQ website].
 
-Then extract the download such as (the .tar)
+Then extract the download with a command of type (assuming that you downloaded a .tar.gz)
 
 ----
-$ tar xf ~/Downloads/apache-activemq-5.13.0-bin.tar.gz
+$ tar xf apache-activemq-x.y.z-bin.tar.gz
 ----
+
+With `x.y.z` the version of Apache ActiveMQ that you downloaded
 
 Then the broker can be started with
 
 ----
-$ cd apache-activemq-5.13.0
+$ cd apache-activemq-x.y.z
 $ bin/activemq console
 ----
 
@@ -58,7 +60,7 @@ When the ActiveMQ broker is running, then you can run this example
 using:
 
 ----
-$ mvn compile exec:java
+$ mvn exec:java
 ----
 
 When the Camel application runs, you should see 2 orders being processed

--- a/examples/widget-gadget-java/pom.xml
+++ b/examples/widget-gadget-java/pom.xml
@@ -114,6 +114,12 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j2-version}</version>
         </dependency>
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/widget-gadget-java/src/main/java/org/apache/camel/example/widget/WidgetGadgetRoute.java
+++ b/examples/widget-gadget-java/src/main/java/org/apache/camel/example/widget/WidgetGadgetRoute.java
@@ -32,10 +32,10 @@ public class WidgetGadgetRoute extends RouteBuilder {
         // it is more common to inline the endpoints and predicates in the route
         // as shown in the CreateOrderRoute
 
-        Endpoint newOrder = endpoint("activemq:queue:newOrder");
+        Endpoint newOrder = getContext().getEndpoint("activemq:queue:newOrder");
         Predicate isWidget = xpath("/order/product = 'widget'");
-        Endpoint widget = endpoint("activemq:queue:widget");
-        Endpoint gadget = endpoint("activemq:queue:gadget");
+        Endpoint widget = getContext().getEndpoint("activemq:queue:widget");
+        Endpoint gadget = getContext().getEndpoint("activemq:queue:gadget");
 
         from(newOrder)
             .choice()

--- a/examples/widget-gadget-java/src/test/java/org/apache/camel/example/widget/WidgetGadgetTest.java
+++ b/examples/widget-gadget-java/src/test/java/org/apache/camel/example/widget/WidgetGadgetTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.widget;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.ConnectionFactory;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.camel.CamelContext;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.component.jms.JmsComponent;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A unit test checking that the Widget and Gadget use-case from the Enterprise Integration Patterns book works
+ * properly using Apache ActiveMQ.
+ */
+class WidgetGadgetTest extends CamelTestSupport {
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        // create CamelContext
+        CamelContext camelContext = super.createCamelContext();
+        // connect to embedded ActiveMQ JMS broker
+        ConnectionFactory connectionFactory =
+                new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+        camelContext.addComponent("activemq",
+                JmsComponent.jmsComponentAutoAcknowledge(connectionFactory));
+
+        return camelContext;
+    }
+
+    @Test
+    void should_distribute_orders() {
+        NotifyBuilder notify = new NotifyBuilder(context)
+                .whenCompleted(1).wereSentTo("activemq:queue:widget")
+                .and().whenCompleted(1).wereSentTo("activemq:queue:gadget")
+                .create();
+
+        assertTrue(
+            notify.matches(10, TimeUnit.SECONDS),
+            "One order should be distributed to widget and and the other to gadget"
+        );
+    }
+
+    @Override
+    protected RoutesBuilder[] createRouteBuilders() {
+        return new RoutesBuilder[]{new CreateOrderRoute(), new WidgetGadgetRoute()};
+    }
+}

--- a/examples/widget-gadget-xml/README.adoc
+++ b/examples/widget-gadget-xml/README.adoc
@@ -11,7 +11,7 @@ processing. The example uses the most famous pattern from the EIP book,
 which is the Content Based Router.
 
 The example is implemented in Spring XML only without using any kind of
-_application server_ but or Java code.
+_application server_ but just a plain old _Java Main_.
 
 ==== Camel component used in this example
 
@@ -25,26 +25,28 @@ _application server_ but or Java code.
 You will need to build this example first:
 
 ----
-$ mvn install
+$ mvn compile
 ----
 
 === Run
 
 This example requires an existing Apache ActiveMQ broker running.
 
-To setup and run Apache ActiveMQ then download it from the
+To set up and run Apache ActiveMQ, download it first from the
 http://activemq.apache.org/[ActiveMQ website].
 
-Then extract the download such as (the .tar)
+Then extract the download with a command of type (assuming that you downloaded a .tar.gz)
 
 ----
-$ tar xf ~/Downloads/apache-activemq-5.13.0-bin.tar.gz
+$ tar xf apache-activemq-x.y.z-bin.tar.gz
 ----
+
+With `x.y.z` the version of Apache ActiveMQ that you downloaded
 
 Then the broker can be started with
 
 ----
-$ cd apache-activemq-5.13.0
+$ cd apache-activemq-x.y.z
 $ bin/activemq console
 ----
 
@@ -59,7 +61,7 @@ When the ActiveMQ broker is running, then you can run this example
 using:
 
 ----
-$ mvn compile exec:java
+$ mvn exec:java
 ----
 
 When the Camel application runs, you should see 2 orders being processed

--- a/examples/widget-gadget-xml/pom.xml
+++ b/examples/widget-gadget-xml/pom.xml
@@ -119,7 +119,18 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j2-version}</version>
         </dependency>
-
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-kahadb-store</artifactId>
+            <version>${activemq-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/widget-gadget-xml/src/main/resources/META-INF/spring/widget.xml
+++ b/examples/widget-gadget-xml/src/main/resources/META-INF/spring/widget.xml
@@ -47,7 +47,7 @@
 
     <!-- A simple route that routes orders from the file system to the ActiveMQ newOrder queue. -->
     <route id="fileToOrder">
-      <!-- route files form src/data (noop = keep the file as-is after done, and do not pickup the same file again) -->
+      <!-- route files form src/data (noop = keep the file as-is after done, and do not pick up the same file again) -->
       <from uri="file:src/data?noop=true"/>
       <!-- route to the newOrder queue on the ActiveMQ broker -->
       <to uri="activemq:queue:newOrder"/>

--- a/examples/widget-gadget-xml/src/test/java/org/apache/camel/example/WidgetGadgetTest.java
+++ b/examples/widget-gadget-xml/src/test/java/org/apache/camel/example/WidgetGadgetTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.camel.test.spring.junit5.CamelSpringTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A unit test checking that the Widget and Gadget use-case from the Enterprise Integration Patterns book works
+ * properly using Apache ActiveMQ.
+ */
+@CamelSpringTest
+@ContextConfiguration(locations = {"/META-INF/spring/widget.xml", "/broker.xml"})
+class WidgetGadgetTest {
+
+    @Autowired
+    ModelCamelContext context;
+
+    @Test
+    void should_distribute_orders() throws Exception {
+        NotifyBuilder notify = new NotifyBuilder(context)
+                .whenCompleted(1).wereSentTo("activemq:queue:widget")
+                .and().whenCompleted(1).wereSentTo("activemq:queue:gadget")
+                .create();
+
+        assertTrue(
+                notify.matches(10, TimeUnit.SECONDS),
+                "One order should be distributed to widget and and the other to gadget"
+        );
+    }
+}

--- a/examples/widget-gadget-xml/src/test/resources/broker.xml
+++ b/examples/widget-gadget-xml/src/test/resources/broker.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!-- START SNIPPET: e1 -->
+<!-- this is a spring XML file where we have ActiveMQ Broker embedded -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="
+	   http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd
+	   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<!-- create an ActiveMQ broker -->
+	<!-- do not use the shutdown hook as it would cause the broker to shut down when you press ctrl + c,
+	     instead we will let Spring shutdown the broker -->
+	<!-- notice this is a basic AMQ broker configuration, for production usage there is many more
+	     options you may need to configure accordingly to your needs -->
+	<broker id="broker" brokerName="myBroker" useShutdownHook="false" useJmx="true"
+				   persistent="true" dataDirectory="target/activemq"
+				   xmlns="http://activemq.apache.org/schema/core">
+
+		<transportConnectors>
+			<!-- tcp for external communication -->
+			<transportConnector name="tcp" uri="tcp://0.0.0.0:61616"/>
+		</transportConnectors>
+
+	</broker>
+</beans>
+<!-- END SNIPPET: e1 -->


### PR DESCRIPTION
## Motivation

Most of the Camel examples don't have any test such that they need to be launched manually to ensure that they still work which is not convenient.

## Modifications:

* Replace the incorrect (jgroups) static import of  `assertTrue` with the right one (junit)
* Remove useless namespace definitions
* Fix the readme.doc (wording, grammar, out dated info, typos)
* Add a build section in all readme.doc for consistency
* Improve the scripts used to test the example `spring-security` by removing the version extracted from the pom file and by redirecting the output to a file into the target directory to avoid having to make git ignore them
* Fix deprecated code
* Improve existing code by using `try-with-resources` statement to properly close the resources
* Refactor the entry class of the example twitter-websocket to make it easier to test 