### PR TITLE
Set the proper parameter name for the listen method in as2 example

### DIFF
--- a/examples/as2/src/main/resources/META-INF/spring/camel-context.xml
+++ b/examples/as2/src/main/resources/META-INF/spring/camel-context.xml
@@ -34,7 +34,7 @@
 		xmlns="http://camel.apache.org/schema/spring">
         <route id="server-route">
           <from
-              uri="as2://server/listen?requestUri=/&amp;serverPortNumber=8888"/>
+              uri="as2://server/listen?requestUriPattern=/&amp;serverPortNumber=8888"/>
           <to uri="bean:examine-as2-server-endpoint-exchange"/>
         </route>
         <route id="triger-clients-route">


### PR DESCRIPTION
## Motivation

When try to launch the example as2, we get the next error:

```
java.lang.reflect.InvocationTargetException
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:401)
    at java.lang.Thread.run (Thread.java:829)
Caused by: org.apache.camel.FailedToStartRouteException: Failed to start route server-route because of null
    at org.apache.camel.impl.engine.RouteService.setUp (RouteService.java:132)
    at org.apache.camel.impl.engine.InternalRouteStartupManager.doInitRoutes (InternalRouteStartupManager.java:92)
    at org.apache.camel.impl.engine.AbstractCamelContext.doInit (AbstractCamelContext.java:2925)
    at org.apache.camel.support.service.BaseService.init (BaseService.java:83)
    at org.apache.camel.impl.engine.AbstractCamelContext.init (AbstractCamelContext.java:2606)
    at org.apache.camel.support.service.BaseService.start (BaseService.java:111)
    at org.apache.camel.impl.engine.AbstractCamelContext.start (AbstractCamelContext.java:2625)
    at org.apache.camel.impl.DefaultCamelContext.start (DefaultCamelContext.java:247)
    at org.apache.camel.spring.SpringCamelContext.start (SpringCamelContext.java:119)
    at org.apache.camel.spring.xml.CamelContextFactoryBean.start (CamelContextFactoryBean.java:430)
    at org.apache.camel.spring.xml.CamelContextFactoryBean.onApplicationEvent (CamelContextFactoryBean.java:485)
    at org.apache.camel.spring.xml.CamelContextFactoryBean.onApplicationEvent (CamelContextFactoryBean.java:99)
    at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener (SimpleApplicationEventMulticaster.java:176)
    at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener (SimpleApplicationEventMulticaster.java:169)
    at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent (SimpleApplicationEventMulticaster.java:143)
    at org.springframework.context.support.AbstractApplicationContext.publishEvent (AbstractApplicationContext.java:421)
    at org.springframework.context.support.AbstractApplicationContext.publishEvent (AbstractApplicationContext.java:378)
    at org.springframework.context.support.AbstractApplicationContext.finishRefresh (AbstractApplicationContext.java:938)
    at org.springframework.context.support.AbstractApplicationContext.refresh (AbstractApplicationContext.java:586)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:144)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:95)
    at org.apache.camel.spring.Main.createDefaultApplicationContext (Main.java:289)
    at org.apache.camel.spring.Main.doStart (Main.java:195)
    at org.apache.camel.support.service.BaseService.start (BaseService.java:119)
    at org.apache.camel.main.MainSupport.run (MainSupport.java:72)
    at org.apache.camel.main.MainCommandLineSupport.run (MainCommandLineSupport.java:175)
    at org.apache.camel.spring.Main.main (Main.java:97)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:401)
    at java.lang.Thread.run (Thread.java:829)
Caused by: java.lang.IllegalArgumentException: Missing properties for server/listen, need one or more from [requestUriPattern]
    at org.apache.camel.support.component.ApiConsumerHelper.findMethod (ApiConsumerHelper.java:64)
    at org.apache.camel.support.component.AbstractApiConsumer.<init> (AbstractApiConsumer.java:48)
    at org.apache.camel.component.as2.AS2Consumer.<init> (AS2Consumer.java:65)
    at org.apache.camel.component.as2.AS2Endpoint.createConsumer (AS2Endpoint.java:94)
    at org.apache.camel.impl.engine.DefaultRoute.gatherRootServices (DefaultRoute.java:620)
    at org.apache.camel.impl.engine.DefaultRoute.gatherServices (DefaultRoute.java:604)
    at org.apache.camel.impl.engine.DefaultRoute.initializeServices (DefaultRoute.java:189)
    at org.apache.camel.impl.engine.RouteService.doSetup (RouteService.java:151)
    at org.apache.camel.impl.engine.RouteService.setUp (RouteService.java:130)
    at org.apache.camel.impl.engine.InternalRouteStartupManager.doInitRoutes (InternalRouteStartupManager.java:92)
    at org.apache.camel.impl.engine.AbstractCamelContext.doInit (AbstractCamelContext.java:2925)
    at org.apache.camel.support.service.BaseService.init (BaseService.java:83)
    at org.apache.camel.impl.engine.AbstractCamelContext.init (AbstractCamelContext.java:2606)
    at org.apache.camel.support.service.BaseService.start (BaseService.java:111)
    at org.apache.camel.impl.engine.AbstractCamelContext.start (AbstractCamelContext.java:2625)
    at org.apache.camel.impl.DefaultCamelContext.start (DefaultCamelContext.java:247)
    at org.apache.camel.spring.SpringCamelContext.start (SpringCamelContext.java:119)
    at org.apache.camel.spring.xml.CamelContextFactoryBean.start (CamelContextFactoryBean.java:430)
    at org.apache.camel.spring.xml.CamelContextFactoryBean.onApplicationEvent (CamelContextFactoryBean.java:485)
    at org.apache.camel.spring.xml.CamelContextFactoryBean.onApplicationEvent (CamelContextFactoryBean.java:99)
    at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener (SimpleApplicationEventMulticaster.java:176)
    at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener (SimpleApplicationEventMulticaster.java:169)
    at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent (SimpleApplicationEventMulticaster.java:143)
    at org.springframework.context.support.AbstractApplicationContext.publishEvent (AbstractApplicationContext.java:421)
    at org.springframework.context.support.AbstractApplicationContext.publishEvent (AbstractApplicationContext.java:378)
    at org.springframework.context.support.AbstractApplicationContext.finishRefresh (AbstractApplicationContext.java:938)
    at org.springframework.context.support.AbstractApplicationContext.refresh (AbstractApplicationContext.java:586)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:144)
    at org.springframework.context.support.ClassPathXmlApplicationContext.<init> (ClassPathXmlApplicationContext.java:95)
    at org.apache.camel.spring.Main.createDefaultApplicationContext (Main.java:289)
    at org.apache.camel.spring.Main.doStart (Main.java:195)
    at org.apache.camel.support.service.BaseService.start (BaseService.java:119)
    at org.apache.camel.main.MainSupport.run (MainSupport.java:72)
    at org.apache.camel.main.MainCommandLineSupport.run (MainCommandLineSupport.java:175)
    at org.apache.camel.spring.Main.main (Main.java:97)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:401)
    at java.lang.Thread.run (Thread.java:829)
```

## Modifications:

* Use  `requestUriPattern` instead of `requestUri` as parameter of the listen method as described in the doc https://camel.apache.org/components/3.14.x/as2-component.html#_api_server_method_listen