### PR TITLE
CAMEL-17596: Fix main-xxx examples main entry

### DIFF
--- a/examples/main-artemis/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/main-artemis/src/main/java/org/apache/camel/example/MyApplication.java
@@ -31,7 +31,7 @@ public final class MyApplication {
         Main main = new Main();
         // lets use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
-        main.configure().addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfiguration(MyConfiguration.class);
         // and add the routes (you can specify multiple classes)
         main.configure().addRoutesBuilder(MyRouteBuilder.class);
         // now keep the application running until the JVM is terminated (ctrl + c or sigterm)

--- a/examples/main-artemis/src/main/java/org/apache/camel/example/MyConfiguration.java
+++ b/examples/main-artemis/src/main/java/org/apache/camel/example/MyConfiguration.java
@@ -16,10 +16,13 @@
  */
 package org.apache.camel.example;
 
+import org.apache.camel.CamelConfiguration;
+import org.apache.camel.CamelContext;
+
 /**
  * Class to configure the Camel application.
  */
-public class MyConfiguration {
+public class MyConfiguration implements CamelConfiguration {
 
     /**
      * Creates the Artemis JMS ConnectionFactory and bind it to the Camel registry
@@ -34,7 +37,8 @@ public class MyConfiguration {
 //        return cf;
 //    }
 
-    public void configure() {
+    @Override
+    public void configure(CamelContext camelContext) {
         // this method is optional and can be removed if no additional configuration is needed.
     }
 

--- a/examples/main-artemis/src/main/java/org/apache/camel/example/MyRouteBuilder.java
+++ b/examples/main-artemis/src/main/java/org/apache/camel/example/MyRouteBuilder.java
@@ -21,7 +21,7 @@ import org.apache.camel.builder.RouteBuilder;
 public class MyRouteBuilder extends RouteBuilder {
 
     @Override
-    public void configure() throws Exception {
+    public void configure() {
         from("timer:foo?period={{myPeriod}}")
             .transform(constant("Hello World"))
             .to("jms:queue:cheese");

--- a/examples/main-lambda/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/main-lambda/src/main/java/org/apache/camel/example/MyApplication.java
@@ -29,10 +29,10 @@ public final class MyApplication {
     public static void main(String[] args) throws Exception {
         // use Camels Main class
         Main main = new Main();
-        // lets use a configuration class (you can specify multiple classes)
+        // let's use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
         // the configuration class has the configuration and also the routes to be used
-        main.configure().addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfiguration(MyConfiguration.class);
         // now keep the application running until the JVM is terminated (ctrl + c or sigterm)
         main.run(args);
     }

--- a/examples/main-lambda/src/main/java/org/apache/camel/example/MyConfiguration.java
+++ b/examples/main-lambda/src/main/java/org/apache/camel/example/MyConfiguration.java
@@ -19,11 +19,12 @@ package org.apache.camel.example;
 import org.apache.camel.BindToRegistry;
 import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.LambdaRouteBuilder;
+import org.apache.camel.CamelConfiguration;
 
 /**
  * Class to configure the Camel application.
  */
-public class MyConfiguration {
+public class MyConfiguration implements CamelConfiguration {
 
     @BindToRegistry
     public MyBean myBean(@PropertyInject("hi") String hi, @PropertyInject("bye") String bye) {

--- a/examples/main-xml/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/main-xml/src/main/java/org/apache/camel/example/MyApplication.java
@@ -31,7 +31,7 @@ public final class MyApplication {
         Main main = new Main();
         // lets use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
-        main.configure().addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfiguration(MyConfiguration.class);
         // and add all the XML routes
         main.configure().withRoutesIncludePattern("routes/*.xml");
         // turn on reloading routes on code-changes

--- a/examples/main-xml/src/main/java/org/apache/camel/example/MyConfiguration.java
+++ b/examples/main-xml/src/main/java/org/apache/camel/example/MyConfiguration.java
@@ -17,12 +17,14 @@
 package org.apache.camel.example;
 
 import org.apache.camel.BindToRegistry;
+import org.apache.camel.CamelContext;
 import org.apache.camel.PropertyInject;
+import org.apache.camel.CamelConfiguration;
 
 /**
  * Class to configure the Camel application.
  */
-public class MyConfiguration {
+public class MyConfiguration implements CamelConfiguration {
 
     @BindToRegistry
     public MyBean myBean(@PropertyInject("hi") String hi, @PropertyInject("bye") String bye) {
@@ -30,7 +32,8 @@ public class MyConfiguration {
         return new MyBean(hi, bye);
     }
 
-    public void configure() {
+    @Override
+    public void configure(CamelContext camelContext) {
         // this method is optional and can be removed if no additional configuration is needed.
     }
 

--- a/examples/main-yaml/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/main-yaml/src/main/java/org/apache/camel/example/MyApplication.java
@@ -31,7 +31,7 @@ public final class MyApplication {
         Main main = new Main();
         // lets use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
-        main.configure().addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfiguration(MyConfiguration.class);
         // and add all the YAML routes
         main.configure().withRoutesIncludePattern("routes/*.yaml");
         // turn on reloading routes on code-changes

--- a/examples/main-yaml/src/main/java/org/apache/camel/example/MyConfiguration.java
+++ b/examples/main-yaml/src/main/java/org/apache/camel/example/MyConfiguration.java
@@ -17,12 +17,14 @@
 package org.apache.camel.example;
 
 import org.apache.camel.BindToRegistry;
+import org.apache.camel.CamelContext;
 import org.apache.camel.PropertyInject;
+import org.apache.camel.CamelConfiguration;
 
 /**
  * Class to configure the Camel application.
  */
-public class MyConfiguration {
+public class MyConfiguration implements CamelConfiguration {
 
     @BindToRegistry
     public MyBean myBean(@PropertyInject("hi") String hi, @PropertyInject("bye") String bye) {
@@ -30,7 +32,8 @@ public class MyConfiguration {
         return new MyBean(hi, bye);
     }
 
-    public void configure() {
+    @Override
+    public void configure(CamelContext camelContext) {
         // this method is optional and can be removed if no additional configuration is needed.
     }
 

--- a/examples/main/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/main/src/main/java/org/apache/camel/example/MyApplication.java
@@ -31,7 +31,7 @@ public final class MyApplication {
         Main main = new Main();
         // lets use a configuration class (you can specify multiple classes)
         // (properties are automatic loaded from application.properties)
-        main.configure().addConfigurationClass(MyConfiguration.class);
+        main.configure().addConfiguration(MyConfiguration.class);
         // and add the routes (you can specify multiple classes)
         main.configure().addRoutesBuilder(MyRouteBuilder.class);
         // now keep the application running until the JVM is terminated (ctrl + c or sigterm)

--- a/examples/main/src/main/java/org/apache/camel/example/MyConfiguration.java
+++ b/examples/main/src/main/java/org/apache/camel/example/MyConfiguration.java
@@ -17,12 +17,14 @@
 package org.apache.camel.example;
 
 import org.apache.camel.BindToRegistry;
+import org.apache.camel.CamelConfiguration;
+import org.apache.camel.CamelContext;
 import org.apache.camel.PropertyInject;
 
 /**
  * Class to configure the Camel application.
  */
-public class MyConfiguration {
+public class MyConfiguration implements CamelConfiguration {
 
     @BindToRegistry
     public MyBean myBean(@PropertyInject("hi") String hi, @PropertyInject("bye") String bye) {
@@ -30,7 +32,8 @@ public class MyConfiguration {
         return new MyBean(hi, bye);
     }
 
-    public void configure() {
+    @Override
+    public void configure(CamelContext camelContext) {
         // this method is optional and can be removed if no additional configuration is needed.
     }
 

--- a/examples/main/src/main/resources/application.properties
+++ b/examples/main/src/main/resources/application.properties
@@ -34,4 +34,4 @@ myCron = 0/2 * * * * ?
 
 # application properties
 hi = Hello
-
+bye = Bye


### PR DESCRIPTION
### What / Why
The _main-xxx_ examples needs to be updated to use the updated `MainConfigurationProperties` and more specifically to remove the `MainConfigurationProperties#addConfigurationClass` configuration method that has been made private in [CAMEL-17567](https://issues.apache.org/jira/browse/CAMEL-17567).

### How
- Update `MyConfiguration` samples configuration to implement `org.apache.camel.CamelConfiguration`
- Update `MyConfiguration#configure` configuration types signatures to match super-type
- Remove closed `MainConfigurationProperties#addConfigurationClass` usage in favor of `MainConfigurationProperties#addConfiguration`

Refs CAMEL-17567