### PR TITLE
CAMEL-11834: Add tests for Kamelet examples

### DIFF
--- a/examples/kamelet-chucknorris/README.adoc
+++ b/examples/kamelet-chucknorris/README.adoc
@@ -4,7 +4,7 @@
 
 This example shows how you can build a simple Kamelet and use with your Camel applications.
 
-The kamelet is created as a YAML file in the `src/main/resources/kamelets' directory.
+The Kamelet is created as a YAML file in the `src/main/resources/kamelets' directory.
 We have developed a Chuck Norris Kamelet that periodically gets a joke from the Chuck Norris internet database.
 
 A Camel routes is _coded_ in the `my-route.xml` file using the XML DSL that uses the Kamelet,

--- a/examples/kamelet-chucknorris/pom.xml
+++ b/examples/kamelet-chucknorris/pom.xml
@@ -94,7 +94,12 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback-version}</version>
         </dependency>
-
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/kamelet-chucknorris/src/test/java/org/apache/camel/example/KameletChuckNorrisTest.java
+++ b/examples/kamelet-chucknorris/src/test/java/org/apache/camel/example/KameletChuckNorrisTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.spi.PackageScanResourceResolver;
+import org.apache.camel.spi.Resource;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A unit test checking that Camel can use a simple Kamelet.
+ */
+class KameletChuckNorrisTest extends CamelTestSupport {
+
+    @Test
+    void should_use_a_simple_kamelet() {
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
+        assertTrue(
+            notify.matches(20, TimeUnit.SECONDS), "1 message should be completed"
+        );
+    }
+
+    @Override
+    protected RoutesBuilder[] createRouteBuilders() throws Exception {
+        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
+        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
+        final List<RoutesBuilder> routesBuilders = new ArrayList<>();
+        for (Resource resource : resolver.findResources("camel/*")) {
+            routesBuilders.addAll(ecc.getRoutesLoader().findRoutesBuilders(resource));
+        }
+        return routesBuilders.toArray(RoutesBuilder[]::new);
+    }
+}

--- a/examples/kamelet-main/README.adoc
+++ b/examples/kamelet-main/README.adoc
@@ -2,11 +2,11 @@
 
 === Introduction
 
-This example shows how to use ready to use Kamelets you can find at the
+This example shows how to use ready to use Kamelets that you can find at the
 https://camel.apache.org/camel-kamelets/next/[Camel Kamelet Catalog].
 
 The application is run with `KameletMain` class from camel-kamalet-main JAR.
-This makes it easy to run Camel standalone with Kamelet that can be automatic
+This makes it easy to run Camel standalone with Kamelet that can be automatically
 downloaded from github, and to use YAML DSL for creating Camel routes that use the Kamelets.
 The example has no Java code at all.
 
@@ -35,8 +35,8 @@ The application is also built as a _fat jar_ (see `pom.xml`), which you can run 
 
 [source,sh]
 ----
-$ mvn package
-$ java -jar target/camel-example-kamelet-yaml-3.13.0-jar-with-dependencies.jar
+$ mvn package -DskipTests
+$ java -jar target/camel-example-kamelet-main-jar-with-dependencies.jar
 ----
 
 

--- a/examples/kamelet-main/pom.xml
+++ b/examples/kamelet-main/pom.xml
@@ -76,10 +76,27 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback-version}</version>
         </dependency>
-
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Dependencies of the Kamelet that we need to add explicitly for the test -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jsonpath</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-caffeine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.camel</groupId>

--- a/examples/kamelet-main/src/test/java/org/apache/camel/example/KameletMainTest.java
+++ b/examples/kamelet-main/src/test/java/org/apache/camel/example/KameletMainTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.component.kamelet.KameletComponent;
+import org.apache.camel.spi.PackageScanResourceResolver;
+import org.apache.camel.spi.Resource;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A unit test checking that Camel can use a simple Kamelet from the catalog.
+ */
+class KameletMainTest extends CamelTestSupport {
+
+    @Test
+    void should_use_a_simple_kamelet_from_catalog() {
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
+        assertTrue(
+            notify.matches(20, TimeUnit.SECONDS), "1 message should be completed"
+        );
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        KameletComponent component = camelContext.getComponent("kamelet", KameletComponent.class);
+        // Indicates where the kamelet should be found
+        component.setLocation("github:apache:camel-kamelets/kamelets");
+        return camelContext;
+    }
+
+    @Override
+    protected RoutesBuilder[] createRouteBuilders() throws Exception {
+        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
+        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
+        final List<RoutesBuilder> routesBuilders = new ArrayList<>();
+        for (Resource resource : resolver.findResources("camel/*")) {
+            routesBuilders.addAll(ecc.getRoutesLoader().findRoutesBuilders(resource));
+        }
+        return routesBuilders.toArray(RoutesBuilder[]::new);
+    }
+}


### PR DESCRIPTION
## Motivation

Most of the Camel examples don't have any test such that they need to be launched manually to ensure that they still work which is not convenient.

## Modifications:

* Fix the readme.doc (wording, grammar, out dated info, typos)
* Add a `finalName` in the build section of the pom of `kamelet-main` to avoid having to specify the version in the launch command of the jar
* Add statically the runtime dependencies of the Kamelet of `kamelet-main` for the test since it is dynamically managed by `DependencyDownloaderKamelet` and it is not accessible