### PR TITLE
CAMEL-17574: Migrate tests to use camel-test-main-junit5

### DIFF
--- a/examples/artemis/pom.xml
+++ b/examples/artemis/pom.xml
@@ -102,7 +102,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/artemis/src/test/java/org/apache/camel/example/artemis/ArtemisTest.java
+++ b/examples/artemis/src/test/java/org/apache/camel/example/artemis/ArtemisTest.java
@@ -19,10 +19,10 @@ package org.apache.camel.example.artemis;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A unit test checking that the Widget and Gadget use-case from the Enterprise Integration Patterns book works
  * properly using Apache ActiveMQ Artemis.
  */
-class ArtemisTest extends CamelTestSupport {
+class ArtemisTest extends CamelMainTestSupport {
 
     private static ActiveMQServer SERVER;
 
@@ -61,13 +61,8 @@ class ArtemisTest extends CamelTestSupport {
     }
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        // create CamelContext
-        CamelContext camelContext = super.createCamelContext();
-        // connect to ActiveMQ Artemis JMS broker
-        camelContext.addComponent("jms", ArtemisMain.createArtemisComponent());
-
-        return camelContext;
+    protected void bindToRegistry(Registry registry) throws Exception {
+        registry.bind("jms", ArtemisMain.createArtemisComponent());
     }
 
     @Test
@@ -85,7 +80,11 @@ class ArtemisTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new CreateOrderRoute(), new WidgetGadgetRoute()};
+    protected void configure(MainConfigurationProperties configuration) {
+        // add the widget/gadget route
+        configuration.addRoutesBuilder(new WidgetGadgetRoute());
+
+        // add a 2nd route that routes files from src/data to the order queue
+        configuration.addRoutesBuilder(new CreateOrderRoute());
     }
 }

--- a/examples/aws/main-endpointdsl-aws2-s3-kafka/src/test/java/org/apache/camel/example/AwsS3KafkaTest.java
+++ b/examples/aws/main-endpointdsl-aws2-s3-kafka/src/test/java/org/apache/camel/example/AwsS3KafkaTest.java
@@ -16,15 +16,16 @@
  */
 package org.apache.camel.example;
 
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.component.aws2.s3.AWS2S3Constants;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * A unit test checking that Camel can poll an Amazon S3 bucket and put the data into a Kafka topic.
  */
-class AwsS3KafkaTest extends CamelTestSupport {
+class AwsS3KafkaTest extends CamelMainTestSupport {
 
     private static final String AWS_IMAGE = "localstack/localstack:0.13.3";
     private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:6.2.2";
@@ -74,8 +75,6 @@ class AwsS3KafkaTest extends CamelTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
-        // Set the location of the configuration
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
         s3.getConfiguration().setAmazonS3Client(
                 S3Client.builder()
@@ -88,13 +87,14 @@ class AwsS3KafkaTest extends CamelTestSupport {
                 .region(Region.of(AWS_CONTAINER.getRegion()))
                 .build()
         );
-        // Override the host and port of the broker
-        camelContext.getPropertiesComponent().setOverrideProperties(
-            asProperties(
-                "kafkaBrokers", String.format("%s:%d", KAFKA_CONTAINER.getHost(), KAFKA_CONTAINER.getMappedPort(9093))
-            )
-        );
         return camelContext;
+    }
+
+    @Override
+    protected Properties useOverridePropertiesWithPropertiesComponent() {
+        return asProperties(
+            "kafkaBrokers", String.format("%s:%d", KAFKA_CONTAINER.getHost(), KAFKA_CONTAINER.getMappedPort(9093))
+        );
     }
 
     @Test
@@ -113,8 +113,9 @@ class AwsS3KafkaTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyRouteBuilder(), new AddBucketRouteBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
+        configuration.addRoutesBuilder(new AddBucketRouteBuilder());
     }
 
     private static class AddBucketRouteBuilder extends RouteBuilder {

--- a/examples/aws/main-endpointdsl-aws2-s3/src/test/java/org/apache/camel/example/AwsS3Test.java
+++ b/examples/aws/main-endpointdsl-aws2-s3/src/test/java/org/apache/camel/example/AwsS3Test.java
@@ -19,12 +19,12 @@ package org.apache.camel.example;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.component.aws2.s3.AWS2S3Constants;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * A unit test checking that Camel can poll an Amazon S3 bucket.
  */
-class AwsS3Test extends CamelTestSupport {
+class AwsS3Test extends CamelMainTestSupport {
 
     private static final String IMAGE = "localstack/localstack:0.13.3";
     private static LocalStackContainer CONTAINER;
@@ -65,8 +65,6 @@ class AwsS3Test extends CamelTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
-        // Set the location of the configuration
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
         s3.getConfiguration().setAmazonS3Client(
                 S3Client.builder()
@@ -98,8 +96,9 @@ class AwsS3Test extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyRouteBuilder(), new AddBucketRouteBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
+        configuration.addRoutesBuilder(new AddBucketRouteBuilder());
     }
 
     private static class AddBucketRouteBuilder extends RouteBuilder {

--- a/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/src/test/java/org/apache/camel/example/AwsS3Test.java
+++ b/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/src/test/java/org/apache/camel/example/AwsS3Test.java
@@ -19,10 +19,11 @@ package org.apache.camel.example;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * A unit test checking that Camel can store content into an Amazon S3 bucket.
  */
-class AwsS3Test extends CamelTestSupport {
+class AwsS3Test extends CamelMainTestSupport {
 
     private static final String IMAGE = "localstack/localstack:0.13.3";
     private static LocalStackContainer CONTAINER;
@@ -63,8 +64,6 @@ class AwsS3Test extends CamelTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
-        // Set the location of the configuration
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
         s3.getConfiguration().setAmazonS3Client(
                 S3Client.builder()
@@ -89,7 +88,7 @@ class AwsS3Test extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/aws/main-endpointdsl-aws2/aws2-sqs-consumer/src/test/java/org/apache/camel/example/AwsSQSTest.java
+++ b/examples/aws/main-endpointdsl-aws2/aws2-sqs-consumer/src/test/java/org/apache/camel/example/AwsSQSTest.java
@@ -19,11 +19,11 @@ package org.apache.camel.example;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.sqs.Sqs2Component;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * A unit test checking that Camel can consume messages from Amazon SQS.
  */
-class AwsSQSTest extends CamelTestSupport {
+class AwsSQSTest extends CamelMainTestSupport {
 
     private static final String IMAGE = "localstack/localstack:0.13.3";
     private static LocalStackContainer CONTAINER;
@@ -64,8 +64,6 @@ class AwsSQSTest extends CamelTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
-        // Set the location of the configuration
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
         Sqs2Component sqs = camelContext.getComponent("aws2-sqs", Sqs2Component.class);
         sqs.getConfiguration().setAmazonSQSClient(
                 SqsClient.builder()
@@ -95,8 +93,9 @@ class AwsSQSTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyRouteBuilder(), new PublishMessageRouteBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
+        configuration.addRoutesBuilder(new PublishMessageRouteBuilder());
     }
 
     private static class PublishMessageRouteBuilder extends RouteBuilder {

--- a/examples/aws/main-endpointdsl-kafka-aws2-s3/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
+++ b/examples/aws/main-endpointdsl-kafka-aws2-s3/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
@@ -16,14 +16,15 @@
  */
 package org.apache.camel.example;
 
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * A unit test checking that Camel can poll data from a Kafka topic and put it into an Amazon S3 bucket.
  */
-class KafkaAwsS3Test extends CamelTestSupport {
+class KafkaAwsS3Test extends CamelMainTestSupport {
 
     private static final String AWS_IMAGE = "localstack/localstack:0.13.3";
     private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:6.2.2";
@@ -73,8 +74,6 @@ class KafkaAwsS3Test extends CamelTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
-        // Set the location of the configuration
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
         s3.getConfiguration().setAmazonS3Client(
                 S3Client.builder()
@@ -87,13 +86,14 @@ class KafkaAwsS3Test extends CamelTestSupport {
                 .region(Region.of(AWS_CONTAINER.getRegion()))
                 .build()
         );
-        // Override the host and port of the broker
-        camelContext.getPropertiesComponent().setOverrideProperties(
-            asProperties(
-                "kafkaBrokers", String.format("%s:%d", KAFKA_CONTAINER.getHost(), KAFKA_CONTAINER.getMappedPort(9093))
-            )
-        );
         return camelContext;
+    }
+
+    @Override
+    protected Properties useOverridePropertiesWithPropertiesComponent() {
+        return asProperties(
+            "kafkaBrokers", String.format("%s:%d", KAFKA_CONTAINER.getHost(), KAFKA_CONTAINER.getMappedPort(9093))
+        );
     }
 
     @Test
@@ -108,8 +108,9 @@ class KafkaAwsS3Test extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyRouteBuilder(), new LoadKafkaRouteBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
+        configuration.addRoutesBuilder(new LoadKafkaRouteBuilder());
     }
 
     private static class LoadKafkaRouteBuilder extends RouteBuilder {

--- a/examples/aws/pom.xml
+++ b/examples/aws/pom.xml
@@ -48,7 +48,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>

--- a/examples/couchbase-log/pom.xml
+++ b/examples/couchbase-log/pom.xml
@@ -80,7 +80,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/couchbase-log/src/test/java/org/apache/camel/example/CouchbaseTest.java
+++ b/examples/couchbase-log/src/test/java/org/apache/camel/example/CouchbaseTest.java
@@ -16,27 +16,26 @@
  */
 package org.apache.camel.example;
 
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.manager.view.DesignDocument;
 import com.couchbase.client.java.manager.view.View;
 import com.couchbase.client.java.view.DesignDocumentNamespace;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.couchbase.CouchbaseConstants;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.couchbase.BucketDefinition;
 import org.testcontainers.couchbase.CouchbaseContainer;
-
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel consume data from Couchbase.
  */
-class CouchbaseTest extends CamelTestSupport {
+class CouchbaseTest extends CamelMainTestSupport {
 
     private static final String IMAGE = "couchbase/server:7.0.3";
     private static final String BUCKET = "test-bucket-" + System.currentTimeMillis();
@@ -90,13 +89,6 @@ class CouchbaseTest extends CamelTestSupport {
     }
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
-        return camelContext;
-    }
-
-    @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         return asProperties(
             "couchbase.host", CONTAINER.getHost(),
@@ -122,7 +114,7 @@ class CouchbaseTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/csimple-joor/pom.xml
+++ b/examples/csimple-joor/pom.xml
@@ -92,7 +92,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/csimple-joor/src/test/java/org/apache/camel/example/CSimpleJOORTest.java
+++ b/examples/csimple-joor/src/test/java/org/apache/camel/example/CSimpleJOORTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that the compiled simple expressions using jooR compiler are evaluated as expected.
  */
-class CSimpleJOORTest extends CamelTestSupport {
+class CSimpleJOORTest extends CamelMainTestSupport {
 
 
     @Override
@@ -48,7 +48,7 @@ class CSimpleJOORTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/csimple/pom.xml
+++ b/examples/csimple/pom.xml
@@ -85,7 +85,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/csimple/src/test/java/org/apache/camel/example/CSimpleTest.java
+++ b/examples/csimple/src/test/java/org/apache/camel/example/CSimpleTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that the compiled simple expressions are evaluated as expected.
  */
-class CSimpleTest extends CamelTestSupport {
+class CSimpleTest extends CamelMainTestSupport {
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
@@ -47,7 +47,7 @@ class CSimpleTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/debezium/pom.xml
+++ b/examples/debezium/pom.xml
@@ -95,7 +95,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/ftp/pom.xml
+++ b/examples/ftp/pom.xml
@@ -85,7 +85,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/ftp/src/test/java/org/apache/camel/example/ftp/FtpTest.java
+++ b/examples/ftp/src/test/java/org/apache/camel/example/ftp/FtpTest.java
@@ -16,10 +16,15 @@
  */
 package org.apache.camel.example.ftp;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.apache.ftpserver.FtpServer;
 import org.apache.ftpserver.FtpServerFactory;
 import org.apache.ftpserver.filesystem.nativefs.NativeFileSystemFactory;
@@ -32,19 +37,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Properties;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel can read/write from/to a ftp server.
  */
-class FtpTest extends CamelTestSupport {
+class FtpTest extends CamelMainTestSupport {
 
     private static FtpServer SERVER;
     private static int PORT;
@@ -83,10 +82,8 @@ class FtpTest extends CamelTestSupport {
     }
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        camelContext.getPropertiesComponent().setLocation("classpath:ftp.properties");
-        return camelContext;
+    protected String getPropertyPlaceholderLocations() {
+        return "classpath:ftp.properties";
     }
 
     @Override
@@ -119,7 +116,7 @@ class FtpTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyFtpClientRouteBuilder(), new MyFtpServerRouteBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyFtpClientRouteBuilder.class, MyFtpServerRouteBuilder.class);
     }
 }

--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -96,7 +96,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/java8/src/test/java/org/apache/camel/example/java8/Java8Test.java
+++ b/examples/java8/src/test/java/org/apache/camel/example/java8/Java8Test.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.example.java8;
 
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel supports properly lambda expressions and method references.
  */
-class Java8Test extends CamelTestSupport {
+class Java8Test extends CamelMainTestSupport {
 
     @Test
     void should_be_evaluated() {
@@ -40,7 +40,7 @@ class Java8Test extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyApplication.MyRouteBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(new MyApplication.MyRouteBuilder());
     }
 }

--- a/examples/kamelet-chucknorris/pom.xml
+++ b/examples/kamelet-chucknorris/pom.xml
@@ -97,7 +97,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/kamelet-chucknorris/src/test/java/org/apache/camel/example/KameletChuckNorrisTest.java
+++ b/examples/kamelet-chucknorris/src/test/java/org/apache/camel/example/KameletChuckNorrisTest.java
@@ -16,24 +16,19 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.spi.PackageScanResourceResolver;
-import org.apache.camel.spi.Resource;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel can use a simple Kamelet.
  */
-class KameletChuckNorrisTest extends CamelTestSupport {
+class KameletChuckNorrisTest extends CamelMainTestSupport {
 
     @Test
     void should_use_a_simple_kamelet() {
@@ -44,13 +39,7 @@ class KameletChuckNorrisTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() throws Exception {
-        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
-        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
-        final List<RoutesBuilder> routesBuilders = new ArrayList<>();
-        for (Resource resource : resolver.findResources("camel/*")) {
-            routesBuilders.addAll(ecc.getRoutesLoader().findRoutesBuilders(resource));
-        }
-        return routesBuilders.toArray(RoutesBuilder[]::new);
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.withRoutesIncludePattern("camel/*");
     }
 }

--- a/examples/kamelet-main/pom.xml
+++ b/examples/kamelet-main/pom.xml
@@ -79,7 +79,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Dependencies of the Kamelet that we need to add explicitly for the test -->

--- a/examples/kamelet-main/src/test/java/org/apache/camel/example/KameletMainTest.java
+++ b/examples/kamelet-main/src/test/java/org/apache/camel/example/KameletMainTest.java
@@ -16,18 +16,13 @@
  */
 package org.apache.camel.example;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.kamelet.KameletComponent;
-import org.apache.camel.spi.PackageScanResourceResolver;
-import org.apache.camel.spi.Resource;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can use a simple Kamelet from the catalog.
  */
-class KameletMainTest extends CamelTestSupport {
+class KameletMainTest extends CamelMainTestSupport {
 
     @Test
     void should_use_a_simple_kamelet_from_catalog() {
@@ -55,13 +50,7 @@ class KameletMainTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() throws Exception {
-        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
-        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
-        final List<RoutesBuilder> routesBuilders = new ArrayList<>();
-        for (Resource resource : resolver.findResources("camel/*")) {
-            routesBuilders.addAll(ecc.getRoutesLoader().findRoutesBuilders(resource));
-        }
-        return routesBuilders.toArray(RoutesBuilder[]::new);
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.withRoutesIncludePattern("camel/*");
     }
 }

--- a/examples/kamelet/pom.xml
+++ b/examples/kamelet/pom.xml
@@ -84,7 +84,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/kamelet/src/test/java/org/apache/camel/example/KameletTest.java
+++ b/examples/kamelet/src/test/java/org/apache/camel/example/KameletTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can build routes thanks to Kamelet.
  */
-class KameletTest extends CamelTestSupport {
+class KameletTest extends CamelMainTestSupport {
 
     @Test
     void should_build_routes_from_kamelets() {
@@ -40,7 +40,7 @@ class KameletTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyRouteTemplates(), new MyRoutes()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.withBasePackageScan(MyApplication.class.getPackageName());
     }
 }

--- a/examples/kotlin/pom.xml
+++ b/examples/kotlin/pom.xml
@@ -93,7 +93,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/kotlin/src/test/kotlin/org/apache/camel/example/KotlinTest.kt
+++ b/examples/kotlin/src/test/kotlin/org/apache/camel/example/KotlinTest.kt
@@ -19,8 +19,8 @@ package org.apache.camel.example
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
-import org.apache.camel.RoutesBuilder
-import org.apache.camel.test.junit5.CamelTestSupport
+import org.apache.camel.main.MainConfigurationProperties
+import org.apache.camel.test.main.junit5.CamelMainTestSupport
 import org.apache.http.HttpStatus
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test
 /**
  * A unit test checking that Camel supports Kotlin.
  */
-class KotlinTest: CamelTestSupport() {
+class KotlinTest: CamelMainTestSupport() {
 
     @Test
     fun `should support kotlin`() {
@@ -42,7 +42,7 @@ class KotlinTest: CamelTestSupport() {
         }
     }
 
-    override fun createRouteBuilder(): RoutesBuilder {
-        return MyRouteBuilder()
+    override fun configure(configuration: MainConfigurationProperties) {
+        configuration.addRoutesBuilder(MyRouteBuilder())
     }
 }

--- a/examples/main-artemis/pom.xml
+++ b/examples/main-artemis/pom.xml
@@ -103,7 +103,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-artemis/src/test/java/org/apache/camel/example/MainArtemisTest.java
+++ b/examples/main-artemis/src/test/java/org/apache/camel/example/MainArtemisTest.java
@@ -16,24 +16,23 @@
  */
 package org.apache.camel.example;
 
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.jms.JmsComponent;
 import org.apache.camel.component.jms.JmsConfiguration;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import org.apache.activemq.artemis.core.config.Configuration;
-
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can send and consume messages to/from Apache ActiveMQ Artemis.
  */
-class MainArtemisTest extends CamelTestSupport {
+class MainArtemisTest extends CamelMainTestSupport {
 
     private static ActiveMQServer SERVER;
 
@@ -70,9 +69,7 @@ class MainArtemisTest extends CamelTestSupport {
     }
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        // create CamelContext
-        CamelContext camelContext = super.createCamelContext();
+    protected void bindToRegistry(Registry registry) throws Exception {
         // Sets up the Artemis core protocol connection factory
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61616");
 
@@ -80,9 +77,7 @@ class MainArtemisTest extends CamelTestSupport {
         configuration.setConnectionFactory(connectionFactory);
 
         // connect to ActiveMQ Artemis JMS broker
-        camelContext.addComponent("jms", new JmsComponent(configuration));
-
-        return camelContext;
+        registry.bind("jms", new JmsComponent(configuration));
     }
 
     @Test
@@ -99,7 +94,8 @@ class MainArtemisTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addConfiguration(MyConfiguration.class);
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/main-endpointdsl/pom.xml
+++ b/examples/main-endpointdsl/pom.xml
@@ -85,7 +85,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-endpointdsl/src/test/java/org/apache/camel/example/MainEndpointDSLTest.java
+++ b/examples/main-endpointdsl/src/test/java/org/apache/camel/example/MainEndpointDSLTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel supports routes with endpoints built with the endpoint DSL.
  */
-class MainEndpointDSLTest extends CamelTestSupport {
+class MainEndpointDSLTest extends CamelMainTestSupport {
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
@@ -47,7 +47,7 @@ class MainEndpointDSLTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/main-health/pom.xml
+++ b/examples/main-health/pom.xml
@@ -93,7 +93,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-joor/pom.xml
+++ b/examples/main-joor/pom.xml
@@ -84,7 +84,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-joor/src/test/java/org/apache/camel/example/MainJOORTest.java
+++ b/examples/main-joor/src/test/java/org/apache/camel/example/MainJOORTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel supports jOOR language in the Camel DSL.
  */
-class MainJOORTest extends CamelTestSupport {
+class MainJOORTest extends CamelMainTestSupport {
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
@@ -46,7 +46,7 @@ class MainJOORTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/main-lambda/pom.xml
+++ b/examples/main-lambda/pom.xml
@@ -84,7 +84,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-lambda/src/test/java/org/apache/camel/example/MainLambdaTest.java
+++ b/examples/main-lambda/src/test/java/org/apache/camel/example/MainLambdaTest.java
@@ -16,14 +16,12 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.builder.LambdaRouteBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -31,36 +29,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A unit test checking that {@code LambdaRouteBuilder} can be used to define routes
  * using lambda style.
  */
-class MainLambdaTest extends CamelTestSupport {
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
-        return camelContext;
-    }
-
-    @Override
-    protected void postProcessTest() throws Exception {
-        super.postProcessTest();
-        context.getInjector().newInstance(MyConfiguration.class);
-    }
+class MainLambdaTest extends CamelMainTestSupport {
 
     @Test
     void should_support_routes_defined_using_a_lambda() throws Exception {
-        // We need to add the route manually for the test
-        LambdaRouteBuilder builder = context.getRegistry().findByType(LambdaRouteBuilder.class).iterator().next();
-        context.addRoutes(new RouteBuilder(context) {
-            @Override
-            public void configure() throws Exception {
-                builder.accept(this);
-            }
-        });
-        context.start();
         NotifyBuilder notify = new NotifyBuilder(context)
             .whenCompleted(1).whenBodiesDone("Bye World").create();
         assertTrue(
             notify.matches(20, TimeUnit.SECONDS), "1 message should be completed"
         );
+    }
+
+    @Override
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.withBasePackageScan(MyApplication.class.getPackageName());
     }
 }

--- a/examples/main-tiny/pom.xml
+++ b/examples/main-tiny/pom.xml
@@ -80,7 +80,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-tiny/src/test/java/org/apache/camel/example/MainTinyTest.java
+++ b/examples/main-tiny/src/test/java/org/apache/camel/example/MainTinyTest.java
@@ -16,14 +16,13 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,16 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can work in tiny mode.
  */
-class MainTinyTest extends CamelTestSupport {
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        MyBean myBean = new MyBean();
-        myBean.setHi("Hello");
-        camelContext.getRegistry().bind("myBean", myBean);
-        return camelContext;
-    }
+class MainTinyTest extends CamelMainTestSupport {
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
@@ -56,7 +46,7 @@ class MainTinyTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/main-xml/pom.xml
+++ b/examples/main-xml/pom.xml
@@ -95,7 +95,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-xml/src/test/java/org/apache/camel/example/MainXMLTest.java
+++ b/examples/main-xml/src/test/java/org/apache/camel/example/MainXMLTest.java
@@ -16,37 +16,19 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.spi.PackageScanResourceResolver;
-import org.apache.camel.spi.Resource;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.TimeUnit;
 
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A unit test checking that Camel supports XML routes.
  */
-class MainXMLTest extends CamelTestSupport {
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
-        return camelContext;
-    }
-
-    @Override
-    protected void postProcessTest() throws Exception {
-        super.postProcessTest();
-        context.getInjector().newInstance(MyConfiguration.class);
-    }
+class MainXMLTest extends CamelMainTestSupport {
 
     @Test
     void should_support_xml_routes() {
@@ -57,14 +39,8 @@ class MainXMLTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() throws Exception {
-        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
-        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
-        for (Resource resource : resolver.findResources("/routes/my-route.xml")) {
-            // Only one file is expected
-            return ecc.getRoutesLoader().findRoutesBuilders(resource).toArray(RoutesBuilder[]::new);
-        }
-        fail("Should find the routes");
-        return null;
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addConfiguration(MyConfiguration.class);
+        configuration.withRoutesIncludePattern("routes/*.xml");
     }
 }

--- a/examples/main-yaml/pom.xml
+++ b/examples/main-yaml/pom.xml
@@ -94,7 +94,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main-yaml/src/test/java/org/apache/camel/example/MainYAMLTest.java
+++ b/examples/main-yaml/src/test/java/org/apache/camel/example/MainYAMLTest.java
@@ -16,37 +16,19 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.spi.PackageScanResourceResolver;
-import org.apache.camel.spi.Resource;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.TimeUnit;
 
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A unit test checking that Camel supports YAML routes.
  */
-class MainYAMLTest extends CamelTestSupport {
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
-        return camelContext;
-    }
-
-    @Override
-    protected void postProcessTest() throws Exception {
-        super.postProcessTest();
-        context.getInjector().newInstance(MyConfiguration.class);
-    }
+class MainYAMLTest extends CamelMainTestSupport {
 
     @Test
     void should_support_yaml_routes() {
@@ -57,13 +39,7 @@ class MainYAMLTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() throws Exception {
-        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
-        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
-        for (Resource resource : resolver.findResources("/routes/my-route.yaml")) {
-            return ecc.getRoutesLoader().findRoutesBuilders(resource).toArray(RoutesBuilder[]::new);
-        }
-        fail("Should find the routes");
-        return null;
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.withBasePackageScan(MyApplication.class.getPackageName());
     }
 }

--- a/examples/main/pom.xml
+++ b/examples/main/pom.xml
@@ -88,7 +88,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/main/src/test/java/org/apache/camel/example/MainTest.java
+++ b/examples/main/src/test/java/org/apache/camel/example/MainTest.java
@@ -16,34 +16,19 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel supports binding via annotations.
  */
-class MainTest extends CamelTestSupport {
-
-    @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        camelContext.getPropertiesComponent().setLocation("classpath:application.properties");
-        camelContext.getPropertiesComponent().addLocation("file:src/main/data/foo.properties");
-        return camelContext;
-    }
-
-    @Override
-    protected void postProcessTest() throws Exception {
-        super.postProcessTest();
-        context.getInjector().newInstance(MyConfiguration.class);
-    }
+class MainTest extends CamelMainTestSupport {
 
     @Test
     void should_support_binding_via_annotations() {
@@ -55,7 +40,7 @@ class MainTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.withBasePackageScan(MyApplication.class.getPackageName());
     }
 }

--- a/examples/mongodb/pom.xml
+++ b/examples/mongodb/pom.xml
@@ -79,7 +79,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/mongodb/src/test/java/org/apache/camel/example/mongodb/MongoDBTest.java
+++ b/examples/mongodb/src/test/java/org/apache/camel/example/mongodb/MongoDBTest.java
@@ -16,19 +16,19 @@
  */
 package org.apache.camel.example.mongodb;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.mongodb.client.MongoClients;
 import io.restassured.response.Response;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can execute CRUD operations against MongoDB.
  */
-class MongoDBTest extends CamelTestSupport {
+class MongoDBTest extends CamelMainTestSupport {
 
     private static final String IMAGE = "mongo:5.0";
     private static MongoDBContainer CONTAINER;
@@ -59,14 +59,11 @@ class MongoDBTest extends CamelTestSupport {
     }
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        // Bind the MongoDB client with the host and port of the container
-        camelContext.getRegistry().bind(
+    protected void bindToRegistry(Registry registry) throws Exception {
+        registry.bind(
             "myDb",
             MongoClients.create(String.format("mongodb://%s:%d", CONTAINER.getHost(), CONTAINER.getMappedPort(27017)))
         );
-        return camelContext;
     }
 
     @Test
@@ -103,9 +100,9 @@ class MongoDBTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{
-            new MongoDBFindByIDRouteBuilder(), new MongoDBFindAllRouteBuilder(), new MongoDBInsertRouteBuilder()
-        };
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(new MongoDBFindByIDRouteBuilder());
+        configuration.addRoutesBuilder(new MongoDBFindAllRouteBuilder());
+        configuration.addRoutesBuilder(new MongoDBInsertRouteBuilder());
     }
 }

--- a/examples/netty-custom-correlation/pom.xml
+++ b/examples/netty-custom-correlation/pom.xml
@@ -88,7 +88,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/netty-custom-correlation/src/test/java/org/apache/camel/example/netty/NettyTest.java
+++ b/examples/netty-custom-correlation/src/test/java/org/apache/camel/example/netty/NettyTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.camel.example.netty;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.Predicate;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.Predicate;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.camel.example.netty.MyClient.createCorrelationManager;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,17 +31,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can communicate over TCP with Netty using a custom codec.
  */
-class NettyTest extends CamelTestSupport {
+class NettyTest extends CamelMainTestSupport {
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
+    protected void bindToRegistry(Registry registry) throws Exception {
         // Bind the Correlation Manager to use for the test
-        camelContext.getRegistry().bind("myManager", createCorrelationManager());
+        registry.bind("myManager", createCorrelationManager());
         // Bind the custom codec
-        camelContext.getRegistry().bind("myEncoder", new MyCodecEncoderFactory());
-        camelContext.getRegistry().bind("myDecoder", new MyCodecDecoderFactory());
-        return camelContext;
+        registry.bind("myEncoder", new MyCodecEncoderFactory());
+        registry.bind("myDecoder", new MyCodecDecoderFactory());
     }
 
     @Test
@@ -56,7 +54,8 @@ class NettyTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyServer.MyRouteBuilder(), new MyClient.MyRouteBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(new MyServer.MyRouteBuilder());
+        configuration.addRoutesBuilder(new MyClient.MyRouteBuilder());
     }
 }

--- a/examples/reactive-executor-vertx/pom.xml
+++ b/examples/reactive-executor-vertx/pom.xml
@@ -96,7 +96,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/reactive-executor-vertx/src/test/java/org/apache/camel/example/VertxTest.java
+++ b/examples/reactive-executor-vertx/src/test/java/org/apache/camel/example/VertxTest.java
@@ -16,22 +16,22 @@
  */
 package org.apache.camel.example;
 
+import java.util.concurrent.TimeUnit;
+
 import io.vertx.core.Vertx;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel can use VertX as reactive executor.
  */
-class VertxTest extends CamelTestSupport {
+class VertxTest extends CamelMainTestSupport {
 
     @AfterEach
     void destroy() {
@@ -42,10 +42,8 @@ class VertxTest extends CamelTestSupport {
     }
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        CamelContext camelContext = super.createCamelContext();
-        camelContext.getRegistry().bind("vertx", Vertx.vertx());
-        return camelContext;
+    protected void bindToRegistry(Registry registry) throws Exception {
+        registry.bind("vertx", Vertx.vertx());
     }
 
     @Test
@@ -57,7 +55,7 @@ class VertxTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return new MyRouteBuilder();
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteBuilder.class);
     }
 }

--- a/examples/routeloader/pom.xml
+++ b/examples/routeloader/pom.xml
@@ -122,7 +122,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/routeloader/src/test/java/org/apache/camel/example/RouteLoaderTest.java
+++ b/examples/routeloader/src/test/java/org/apache/camel/example/RouteLoaderTest.java
@@ -16,24 +16,18 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.spi.PackageScanResourceResolver;
-import org.apache.camel.spi.Resource;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel can load routes dynamically.
  */
-class RouteLoaderTest extends CamelTestSupport {
+class RouteLoaderTest extends CamelMainTestSupport {
 
     @Test
     void should_load_routes_dynamically() {
@@ -44,16 +38,5 @@ class RouteLoaderTest extends CamelTestSupport {
         assertTrue(
             notify.matches(20, TimeUnit.SECONDS), "3 messages should be completed"
         );
-    }
-
-    @Override
-    protected RoutesBuilder[] createRouteBuilders() throws Exception {
-        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
-        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
-        final List<RoutesBuilder> routesBuilders = new ArrayList<>();
-        for (Resource resource : resolver.findResources("myroutes/*")) {
-            routesBuilders.addAll(ecc.getRoutesLoader().findRoutesBuilders(resource));
-        }
-        return routesBuilders.toArray(RoutesBuilder[]::new);
     }
 }

--- a/examples/routes-configuration/pom.xml
+++ b/examples/routes-configuration/pom.xml
@@ -106,7 +106,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/routes-configuration/src/test/java/org/apache/camel/example/RoutesConfigurationTest.java
+++ b/examples/routes-configuration/src/test/java/org/apache/camel/example/RoutesConfigurationTest.java
@@ -16,24 +16,19 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.spi.PackageScanResourceResolver;
-import org.apache.camel.spi.Resource;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel can load routes dynamically.
  */
-class RoutesConfigurationTest extends CamelTestSupport {
+class RoutesConfigurationTest extends CamelMainTestSupport {
 
     @Test
     void should_load_routes_dynamically() {
@@ -47,17 +42,7 @@ class RoutesConfigurationTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() throws Exception {
-        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
-        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
-        final List<RoutesBuilder> routesBuilders = new ArrayList<>();
-        routesBuilders.add(new MyJavaRouteBuilder());
-        routesBuilders.add(new MyJavaErrorHandler());
-        for (String location : List.of("myroutes/*","myerror/*")) {
-            for (Resource resource : resolver.findResources(location)) {
-                routesBuilders.addAll(ecc.getRoutesLoader().findRoutesBuilders(resource));
-            }
-        }
-        return routesBuilders.toArray(RoutesBuilder[]::new);
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyJavaRouteBuilder.class, MyJavaErrorHandler.class);
     }
 }

--- a/examples/routetemplate-xml/pom.xml
+++ b/examples/routetemplate-xml/pom.xml
@@ -90,7 +90,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/routetemplate-xml/src/test/java/org/apache/camel/example/RouteTemplateXMLTest.java
+++ b/examples/routetemplate-xml/src/test/java/org/apache/camel/example/RouteTemplateXMLTest.java
@@ -16,24 +16,19 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.spi.PackageScanResourceResolver;
-import org.apache.camel.spi.Resource;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel supports parameterized routes in XML.
  */
-class RouteTemplateXMLTest extends CamelTestSupport {
+class RouteTemplateXMLTest extends CamelMainTestSupport {
 
     @Test
     void should_support_parameterized_routes() {
@@ -44,15 +39,7 @@ class RouteTemplateXMLTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() throws Exception {
-        final ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
-        final PackageScanResourceResolver resolver = ecc.getPackageScanResourceResolver();
-        final List<RoutesBuilder> routesBuilders = new ArrayList<>();
-        for (String location : List.of("templates/*","builders/*")) {
-            for (Resource resource : resolver.findResources(location)) {
-                routesBuilders.addAll(ecc.getRoutesLoader().findRoutesBuilders(resource));
-            }
-        }
-        return routesBuilders.toArray(RoutesBuilder[]::new);
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.withRoutesIncludePattern("templates/*.xml,builders/*.xml");
     }
 }

--- a/examples/routetemplate/pom.xml
+++ b/examples/routetemplate/pom.xml
@@ -84,7 +84,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/routetemplate/src/test/java/org/apache/camel/example/RouteTemplateTest.java
+++ b/examples/routetemplate/src/test/java/org/apache/camel/example/RouteTemplateTest.java
@@ -16,19 +16,19 @@
  */
 package org.apache.camel.example;
 
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.Test;
-
 import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A unit test checking that Camel supports parameterized routes.
  */
-class RouteTemplateTest extends CamelTestSupport {
+class RouteTemplateTest extends CamelMainTestSupport {
 
     @Test
     void should_support_parameterized_routes() {
@@ -39,7 +39,7 @@ class RouteTemplateTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new MyRouteTemplates(), new MyTemplateBuilder()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MyRouteTemplates.class);
     }
 }

--- a/examples/twitter-websocket/pom.xml
+++ b/examples/twitter-websocket/pom.xml
@@ -90,7 +90,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
+++ b/examples/twitter-websocket/src/main/java/org/apache/camel/example/websocket/CamelTwitterWebSocketMain.java
@@ -50,10 +50,8 @@ public final class CamelTwitterWebSocketMain {
         // create a new Camel Main so we can easily start Camel
         Main main = new Main();
 
-        TwitterWebSocketRoute route = createTwitterWebSocketRoute("gaga", 6_000);
-
         // add our routes to Camel
-        main.configure().addRoutesBuilder(route);
+        main.configure().addRoutesBuilder(createTwitterWebSocketRoute("gaga", 6_000));
 
         // and run, which keeps blocking until we terminate the JVM (or stop CamelContext)
         main.run();

--- a/examples/twitter-websocket/src/test/java/org/apache/camel/example/websocket/CamelTwitterWebSocketTest.java
+++ b/examples/twitter-websocket/src/test/java/org/apache/camel/example/websocket/CamelTwitterWebSocketTest.java
@@ -19,8 +19,8 @@ package org.apache.camel.example.websocket;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.camel.RoutesBuilder;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.ws.WebSocket;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can poll a constant feed of Twitter and publish results using WebSocket.
  */
-class CamelTwitterWebSocketTest extends CamelTestSupport {
+class CamelTwitterWebSocketTest extends CamelMainTestSupport {
 
     @Test
     void should_support_polling_twitter_publishing_websocket() throws Exception {
@@ -74,7 +74,7 @@ class CamelTwitterWebSocketTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder createRouteBuilder() {
-        return createTwitterWebSocketRoute("test", 100);
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(createTwitterWebSocketRoute("test", 100));
     }
 }

--- a/examples/widget-gadget-java/pom.xml
+++ b/examples/widget-gadget-java/pom.xml
@@ -117,7 +117,7 @@
         <!-- for testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-junit5</artifactId>
+            <artifactId>camel-test-main-junit5</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/widget-gadget-java/src/test/java/org/apache/camel/example/widget/WidgetGadgetTest.java
+++ b/examples/widget-gadget-java/src/test/java/org/apache/camel/example/widget/WidgetGadgetTest.java
@@ -19,12 +19,13 @@ package org.apache.camel.example.widget;
 import java.util.concurrent.TimeUnit;
 
 import javax.jms.ConnectionFactory;
+
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.camel.CamelContext;
-import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.jms.JmsComponent;
-import org.apache.camel.test.junit5.CamelTestSupport;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,19 +34,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A unit test checking that the Widget and Gadget use-case from the Enterprise Integration Patterns book works
  * properly using Apache ActiveMQ.
  */
-class WidgetGadgetTest extends CamelTestSupport {
+class WidgetGadgetTest extends CamelMainTestSupport {
 
     @Override
-    protected CamelContext createCamelContext() throws Exception {
-        // create CamelContext
-        CamelContext camelContext = super.createCamelContext();
+    protected void bindToRegistry(Registry registry) throws Exception {
         // connect to embedded ActiveMQ JMS broker
         ConnectionFactory connectionFactory =
                 new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
-        camelContext.addComponent("activemq",
-                JmsComponent.jmsComponentAutoAcknowledge(connectionFactory));
-
-        return camelContext;
+        registry.bind("activemq", JmsComponent.jmsComponentAutoAcknowledge(connectionFactory));
     }
 
     @Test
@@ -62,7 +58,8 @@ class WidgetGadgetTest extends CamelTestSupport {
     }
 
     @Override
-    protected RoutesBuilder[] createRouteBuilders() {
-        return new RoutesBuilder[]{new CreateOrderRoute(), new WidgetGadgetRoute()};
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(new WidgetGadgetRoute());
+        configuration.addRoutesBuilder(new CreateOrderRoute());
     }
 }


### PR DESCRIPTION
## Motivation

A new component has been added to write tests for Camel Main applications, since there are several examples based on Camel Main, it would nice to leverage it to simplify the existing tests of the corresponding examples.

## Modifications

* Use `camel-test-main-junit5` instead of `camel-test-junit5` in all pom of examples based on Camel Main
* Make the corresponding test classes extend `CamelMainTestSupport ` instead of `CamelTestSupport` to be able to use features specific to Camel Main in the tests
* Bind components inside `bindToRegistry` instead of `createCamelContext` as it is more convenient for it
* Override properties by overriding `useOverridePropertiesWithPropertiesComponent` instead of  calling `camelContext.getPropertiesComponent().setOverrideProperties`  as it is more convenient for it
* Call the method `replaceRouteFromWith` to replace a from endpoint instead of advising explicitly the route as it is more convenient for it
* Avoid setting explicitly the location of the configurations from `camelContext.getPropertiesComponent()` as `classpath:application.properties` is the default location by overriding when needed the dedicated method `getPropertyPlaceholderLocations`