### PR TITLE
CAMEL-17574: Specify a main class and avoid overriding getPropertyPlaceholderLocations 

### DIFF
--- a/examples/ftp/src/test/java/org/apache/camel/example/ftp/FtpTest.java
+++ b/examples/ftp/src/test/java/org/apache/camel/example/ftp/FtpTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.camel.test.junit5.TestSupport.createDirectory;
+import static org.apache.camel.test.junit5.TestSupport.deleteDirectory;
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,7 +69,7 @@ class FtpTest extends CamelMainTestSupport {
         serverFactory.setFileSystem(fsf);
 
         // Create the admin home
-        new File("./target/ftp-server").mkdirs();
+        createDirectory("./target/ftp-server");
 
         SERVER = serverFactory.createServer();
         // start the server
@@ -76,14 +78,12 @@ class FtpTest extends CamelMainTestSupport {
 
     @AfterAll
     static void destroy() {
+        // Delete directories
+        deleteDirectory("./target/ftp-server");
+        deleteDirectory("./target/upload");
         if (SERVER != null) {
             SERVER.stop();
         }
-    }
-
-    @Override
-    protected String getPropertyPlaceholderLocations() {
-        return "classpath:ftp.properties";
     }
 
     @Override

--- a/examples/kamelet/src/test/java/org/apache/camel/example/KameletTest.java
+++ b/examples/kamelet/src/test/java/org/apache/camel/example/KameletTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.example;
 
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +39,7 @@ class KameletTest extends CamelMainTestSupport {
     }
 
     @Override
-    protected void configure(MainConfigurationProperties configuration) {
-        configuration.withBasePackageScan(MyApplication.class.getPackageName());
+    protected Class<?> getMainClass() {
+        return MyApplication.class;
     }
 }

--- a/examples/main-lambda/src/test/java/org/apache/camel/example/MainLambdaTest.java
+++ b/examples/main-lambda/src/test/java/org/apache/camel/example/MainLambdaTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.example;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +40,7 @@ class MainLambdaTest extends CamelMainTestSupport {
     }
 
     @Override
-    protected void configure(MainConfigurationProperties configuration) {
-        configuration.withBasePackageScan(MyApplication.class.getPackageName());
+    protected Class<?> getMainClass() {
+        return MyApplication.class;
     }
 }

--- a/examples/main-yaml/src/test/java/org/apache/camel/example/MainYAMLTest.java
+++ b/examples/main-yaml/src/test/java/org/apache/camel/example/MainYAMLTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.example;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ class MainYAMLTest extends CamelMainTestSupport {
     }
 
     @Override
-    protected void configure(MainConfigurationProperties configuration) {
-        configuration.withBasePackageScan(MyApplication.class.getPackageName());
+    protected Class<?> getMainClass() {
+        return MyApplication.class;
     }
 }

--- a/examples/main/src/test/java/org/apache/camel/example/MainTest.java
+++ b/examples/main/src/test/java/org/apache/camel/example/MainTest.java
@@ -19,7 +19,6 @@ package org.apache.camel.example;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +39,7 @@ class MainTest extends CamelMainTestSupport {
     }
 
     @Override
-    protected void configure(MainConfigurationProperties configuration) {
-        configuration.withBasePackageScan(MyApplication.class.getPackageName());
+    protected Class<?> getMainClass() {
+        return MyApplication.class;
     }
 }


### PR DESCRIPTION
## Motivation

https://github.com/apache/camel/pull/6996 brings improvements like the ability to specify a main class to reduce the complexity of the test, the tests of examples should benefit from those improvements.

## Modifications:

* Override the method `getMainClass()` to specify the main class instead of explicitly calling `withBasePackageScan(MyApplication.class.getPackageName())`
* Avoid overriding `getPropertyPlaceholderLocations` in the test `FtpTest` to specify the location of `ftp.properties` as it is already set in the `RouteBuilders`
* Use the static methods `createDirectory` and `deleteDirectory` from `TestSupport` when needed to clean up the test