### PR TITLE
Simplify the tests by using the testcontainers' extension

### DIFF
--- a/examples/aws/main-endpointdsl-aws2-s3-kafka/src/test/java/org/apache/camel/example/AwsS3KafkaTest.java
+++ b/examples/aws/main-endpointdsl-aws2-s3-kafka/src/test/java/org/apache/camel/example/AwsS3KafkaTest.java
@@ -26,12 +26,12 @@ import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -45,32 +45,18 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * A unit test checking that Camel can poll an Amazon S3 bucket and put the data into a Kafka topic.
  */
+@Testcontainers
 class AwsS3KafkaTest extends CamelMainTestSupport {
 
     private static final String AWS_IMAGE = "localstack/localstack:0.13.3";
     private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:6.2.2";
-    private static LocalStackContainer AWS_CONTAINER;
-    private static KafkaContainer KAFKA_CONTAINER;
 
-    @BeforeAll
-    static void init() {
-        AWS_CONTAINER = new LocalStackContainer(DockerImageName.parse(AWS_IMAGE))
-                .withServices(S3)
-                .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));;
-        AWS_CONTAINER.start();
-        KAFKA_CONTAINER = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE));
-        KAFKA_CONTAINER.start();
-    }
-
-    @AfterAll
-    static void destroy() {
-        if (AWS_CONTAINER != null) {
-            AWS_CONTAINER.stop();
-        }
-        if (KAFKA_CONTAINER != null) {
-            KAFKA_CONTAINER.stop();
-        }
-    }
+    @Container
+    private final LocalStackContainer awsContainer = new LocalStackContainer(DockerImageName.parse(AWS_IMAGE))
+            .withServices(S3)
+            .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
+    @Container
+    private final KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE));
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -78,13 +64,13 @@ class AwsS3KafkaTest extends CamelMainTestSupport {
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
         s3.getConfiguration().setAmazonS3Client(
                 S3Client.builder()
-                .endpointOverride(AWS_CONTAINER.getEndpointOverride(S3))
+                .endpointOverride(awsContainer.getEndpointOverride(S3))
                 .credentialsProvider(
                     StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(AWS_CONTAINER.getAccessKey(), AWS_CONTAINER.getSecretKey())
+                        AwsBasicCredentials.create(awsContainer.getAccessKey(), awsContainer.getSecretKey())
                     )
                 )
-                .region(Region.of(AWS_CONTAINER.getRegion()))
+                .region(Region.of(awsContainer.getRegion()))
                 .build()
         );
         return camelContext;
@@ -93,7 +79,7 @@ class AwsS3KafkaTest extends CamelMainTestSupport {
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         return asProperties(
-            "kafkaBrokers", String.format("%s:%d", KAFKA_CONTAINER.getHost(), KAFKA_CONTAINER.getMappedPort(9093))
+            "kafkaBrokers", String.format("%s:%d", kafkaContainer.getHost(), kafkaContainer.getMappedPort(9093))
         );
     }
 

--- a/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/src/test/java/org/apache/camel/example/AwsS3Test.java
+++ b/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/src/test/java/org/apache/camel/example/AwsS3Test.java
@@ -22,13 +22,12 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.main.MainConfigurationProperties;
-import org.apache.camel.spi.Registry;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -41,25 +40,15 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 /**
  * A unit test checking that Camel can store content into an Amazon S3 bucket.
  */
+@Testcontainers
 class AwsS3Test extends CamelMainTestSupport {
 
     private static final String IMAGE = "localstack/localstack:0.13.3";
-    private static LocalStackContainer CONTAINER;
 
-    @BeforeAll
-    static void init() {
-        CONTAINER = new LocalStackContainer(DockerImageName.parse(IMAGE))
-                .withServices(S3)
-                .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));;
-        CONTAINER.start();
-    }
-
-    @AfterAll
-    static void destroy() {
-        if (CONTAINER != null) {
-            CONTAINER.stop();
-        }
-    }
+    @Container
+    private final LocalStackContainer container = new LocalStackContainer(DockerImageName.parse(IMAGE))
+            .withServices(S3)
+            .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -67,13 +56,13 @@ class AwsS3Test extends CamelMainTestSupport {
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
         s3.getConfiguration().setAmazonS3Client(
                 S3Client.builder()
-                .endpointOverride(CONTAINER.getEndpointOverride(S3))
+                .endpointOverride(container.getEndpointOverride(S3))
                 .credentialsProvider(
                     StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(CONTAINER.getAccessKey(), CONTAINER.getSecretKey())
+                        AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
                     )
                 )
-                .region(Region.of(CONTAINER.getRegion()))
+                .region(Region.of(container.getRegion()))
                 .build()
         );
         return camelContext;

--- a/examples/aws/pom.xml
+++ b/examples/aws/pom.xml
@@ -59,6 +59,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>1.12.150</version>

--- a/examples/couchbase-log/pom.xml
+++ b/examples/couchbase-log/pom.xml
@@ -89,6 +89,12 @@
             <version>${testcontainers-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/debezium/pom.xml
+++ b/examples/debezium/pom.xml
@@ -117,6 +117,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>1.12.150</version>

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -96,6 +96,12 @@
             <version>${testcontainers-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/examples/kafka/src/test/java/org/apache/camel/example/kafka/KafkaTest.java
+++ b/examples/kafka/src/test/java/org/apache/camel/example/kafka/KafkaTest.java
@@ -23,11 +23,11 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.apache.camel.example.kafka.MessagePublisherClient.setUpKafkaComponent;
@@ -37,23 +37,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can produce and consume messages to / from a Kafka broker.
  */
+@Testcontainers
 class KafkaTest extends CamelTestSupport {
 
     private static final String IMAGE = "confluentinc/cp-kafka:6.2.2";
-    private static KafkaContainer CONTAINER;
 
-    @BeforeAll
-    static void init() {
-        CONTAINER = new KafkaContainer(DockerImageName.parse(IMAGE));
-        CONTAINER.start();
-    }
-
-    @AfterAll
-    static void destroy() {
-        if (CONTAINER != null) {
-            CONTAINER.stop();
-        }
-    }
+    @Container
+    private final KafkaContainer container = new KafkaContainer(DockerImageName.parse(IMAGE));
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -63,8 +53,8 @@ class KafkaTest extends CamelTestSupport {
         // Override the host and port of the broker
         camelContext.getPropertiesComponent().setOverrideProperties(
             asProperties(
-                "kafka.host", CONTAINER.getHost(),
-                "kafka.port", Integer.toString(CONTAINER.getMappedPort(9093))
+                "kafka.host", container.getHost(),
+                "kafka.port", Integer.toString(container.getMappedPort(9093))
             )
         );
         setUpKafkaComponent(camelContext);

--- a/examples/mongodb/pom.xml
+++ b/examples/mongodb/pom.xml
@@ -89,6 +89,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${rest-assured-version}</version>

--- a/examples/mongodb/src/test/java/org/apache/camel/example/mongodb/MongoDBTest.java
+++ b/examples/mongodb/src/test/java/org/apache/camel/example/mongodb/MongoDBTest.java
@@ -24,10 +24,10 @@ import io.restassured.response.Response;
 import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.spi.Registry;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import static io.restassured.RestAssured.given;
@@ -38,31 +38,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can execute CRUD operations against MongoDB.
  */
+@Testcontainers
 class MongoDBTest extends CamelMainTestSupport {
 
     private static final String IMAGE = "mongo:5.0";
-    private static MongoDBContainer CONTAINER;
 
     private static final String BASE_URI = "http://localhost:8081";
 
-    @BeforeAll
-    static void init() {
-        CONTAINER = new MongoDBContainer(DockerImageName.parse(IMAGE));
-        CONTAINER.start();
-    }
-
-    @AfterAll
-    static void destroy() {
-        if (CONTAINER != null) {
-            CONTAINER.stop();
-        }
-    }
+    @Container
+    private final MongoDBContainer container = new MongoDBContainer(DockerImageName.parse(IMAGE));
 
     @Override
     protected void bindToRegistry(Registry registry) throws Exception {
         registry.bind(
             "myDb",
-            MongoClients.create(String.format("mongodb://%s:%d", CONTAINER.getHost(), CONTAINER.getMappedPort(27017)))
+            MongoClients.create(String.format("mongodb://%s:%d", container.getHost(), container.getMappedPort(27017)))
         );
     }
 

--- a/examples/vertx-kafka/pom.xml
+++ b/examples/vertx-kafka/pom.xml
@@ -104,6 +104,12 @@
             <version>${testcontainers-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/examples/vertx-kafka/src/test/java/org/apache/camel/example/vertx/kafka/VertxKafkaTest.java
+++ b/examples/vertx-kafka/src/test/java/org/apache/camel/example/vertx/kafka/VertxKafkaTest.java
@@ -23,11 +23,11 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.test.junit5.CamelTestSupport;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.apache.camel.example.vertx.kafka.MessagePublisherClient.setUpKafkaComponent;
@@ -38,23 +38,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A unit test checking that Camel can produce and consume messages to / from a Kafka broker using the Kafka Vertx
  * component.
  */
+@Testcontainers
 class VertxKafkaTest extends CamelTestSupport {
 
     private static final String IMAGE = "confluentinc/cp-kafka:6.2.2";
-    private static KafkaContainer CONTAINER;
 
-    @BeforeAll
-    static void init() {
-        CONTAINER = new KafkaContainer(DockerImageName.parse(IMAGE));
-        CONTAINER.start();
-    }
-
-    @AfterAll
-    static void destroy() {
-        if (CONTAINER != null) {
-            CONTAINER.stop();
-        }
-    }
+    @Container
+    private final KafkaContainer container = new KafkaContainer(DockerImageName.parse(IMAGE));
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -64,8 +54,8 @@ class VertxKafkaTest extends CamelTestSupport {
         // Override the host and port of the broker
         camelContext.getPropertiesComponent().setOverrideProperties(
             asProperties(
-                "kafka.host", CONTAINER.getHost(),
-                "kafka.port", Integer.toString(CONTAINER.getMappedPort(9093))
+                "kafka.host", container.getHost(),
+                "kafka.port", Integer.toString(container.getMappedPort(9093))
             )
         );
         setUpKafkaComponent(camelContext);


### PR DESCRIPTION
## Motivation

There is an extension of testcontainers for JUnit5 that we should use to simplify the test classes.

## Modifications:

* Add the annotations specific to the testcontainers's extension
* Convert the containers into member fields 