### PR TITLE
CAMEL-17629: camel-health - Removed option to disable context health check as it should always be enabled.

### DIFF
--- a/examples/main-health/src/main/resources/application.properties
+++ b/examples/main-health/src/main/resources/application.properties
@@ -37,8 +37,6 @@ camel.main.route-controller-back-off-max-attempts = 10
 # enable health check (is automatic enabled if discovered on classpath)
 # global flag to enable/disable
 camel.health.enabled = true
-# context check is default included but we can turn it on|off
-camel.health.context-enabled = true
 # routes check is default included but we can turn it on|off
 camel.health.routes-enabled = true
 # registry check is default included but we can turn it on|off


### PR DESCRIPTION
## Motivation

If we launch the example, we end up with the next error:

```
16:36:32.799 [org.apache.camel.example.MyApplication.main()] INFO  org.apache.camel.main.MainSupport - Apache Camel (Main) 3.16.0-SNAPSHOT is starting
[ERROR] *************************************
[ERROR] Error occurred while running main from: org.apache.camel.example.MyApplication
[ERROR] 
java.lang.reflect.InvocationTargetException
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:410)
    at java.lang.Thread.run (Thread.java:829)
Caused by: org.apache.camel.PropertyBindingException: Error binding property (camel.health.contextEnabled=true) with name: contextEnabled on bean: org.apache.camel.main.HealthConfigurationProperties@59ac2450 with value: true
    at org.apache.camel.main.MainHelper.setPropertiesOnTarget (MainHelper.java:344)
    at org.apache.camel.main.BaseMainSupport.setHealthCheckProperties (BaseMainSupport.java:1008)
    at org.apache.camel.main.BaseMainSupport.doConfigureCamelContextFromMainConfiguration (BaseMainSupport.java:894)
    at org.apache.camel.main.BaseMainSupport.autoconfigure (BaseMainSupport.java:430)
    at org.apache.camel.main.BaseMainSupport.postProcessCamelContext (BaseMainSupport.java:586)
    at org.apache.camel.main.MainSupport.initCamelContext (MainSupport.java:395)
    at org.apache.camel.main.Main.doInit (Main.java:130)
    at org.apache.camel.support.service.BaseService.init (BaseService.java:83)
    at org.apache.camel.main.MainSupport.run (MainSupport.java:77)
    at org.apache.camel.main.MainCommandLineSupport.run (MainCommandLineSupport.java:177)
    at org.apache.camel.example.MyApplication.main (MyApplication.java:35)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.camel.maven.RunMojo$1.run (RunMojo.java:410)
    at java.lang.Thread.run (Thread.java:829)
[ERROR] *************************************

```

## Modifications

The problem is due to the fact that the property has been removed by CAMEL-17629 as the context health check should always be enabled. So this PR simply removes the property.