### PR TITLE
Use camel-test-infra instead of testcontainers directly

### DIFF
--- a/examples/aws/main-endpointdsl-aws2-s3-kafka/pom.xml
+++ b/examples/aws/main-endpointdsl-aws2-s3-kafka/pom.xml
@@ -88,9 +88,10 @@
         </dependency>
         <!-- for testing -->
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-kafka</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/aws/main-endpointdsl-aws2-s3-kafka/src/test/java/org/apache/camel/example/AwsS3KafkaTest.java
+++ b/examples/aws/main-endpointdsl-aws2-s3-kafka/src/test/java/org/apache/camel/example/AwsS3KafkaTest.java
@@ -25,61 +25,40 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.infra.aws.common.services.AWSService;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
+import org.apache.camel.test.infra.kafka.services.KafkaService;
+import org.apache.camel.test.infra.kafka.services.KafkaServiceFactory;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 /**
  * A unit test checking that Camel can poll an Amazon S3 bucket and put the data into a Kafka topic.
  */
-@Testcontainers
 class AwsS3KafkaTest extends CamelMainTestSupport {
 
-    private static final String AWS_IMAGE = "localstack/localstack:0.13.3";
-    private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:6.2.2";
-
-    @Container
-    private final LocalStackContainer awsContainer = new LocalStackContainer(DockerImageName.parse(AWS_IMAGE))
-            .withServices(S3)
-            .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
-    @Container
-    private final KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE));
+    @RegisterExtension
+    private static final AWSService AWS_SERVICE = AWSServiceFactory.createS3Service();
+    @RegisterExtension
+    private static final KafkaService KAFKA_SERVICE = KafkaServiceFactory.createService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
-        s3.getConfiguration().setAmazonS3Client(
-                S3Client.builder()
-                .endpointOverride(awsContainer.getEndpointOverride(S3))
-                .credentialsProvider(
-                    StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(awsContainer.getAccessKey(), awsContainer.getSecretKey())
-                    )
-                )
-                .region(Region.of(awsContainer.getRegion()))
-                .build()
-        );
+        s3.getConfiguration().setAmazonS3Client(AWSSDKClientUtils.newS3Client());
         return camelContext;
     }
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         return asProperties(
-            "kafkaBrokers", String.format("%s:%d", kafkaContainer.getHost(), kafkaContainer.getMappedPort(9093))
+            "kafkaBrokers", KAFKA_SERVICE.getBootstrapServers()
         );
     }
 

--- a/examples/aws/main-endpointdsl-aws2-s3/src/test/java/org/apache/camel/example/AwsS3Test.java
+++ b/examples/aws/main-endpointdsl-aws2-s3/src/test/java/org/apache/camel/example/AwsS3Test.java
@@ -24,49 +24,28 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.infra.aws.common.services.AWSService;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 /**
  * A unit test checking that Camel can poll an Amazon S3 bucket.
  */
-@Testcontainers
 class AwsS3Test extends CamelMainTestSupport {
 
-    private static final String IMAGE = "localstack/localstack:0.13.3";
-
-    @Container
-    private final LocalStackContainer container = new LocalStackContainer(DockerImageName.parse(IMAGE))
-            .withServices(S3)
-            .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
+    @RegisterExtension
+    private static final AWSService AWS_SERVICE = AWSServiceFactory.createS3Service();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
-        s3.getConfiguration().setAmazonS3Client(
-                S3Client.builder()
-                .endpointOverride(container.getEndpointOverride(S3))
-                .credentialsProvider(
-                    StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
-                    )
-                )
-                .region(Region.of(container.getRegion()))
-                .build()
-        );
+        s3.getConfiguration().setAmazonS3Client(AWSSDKClientUtils.newS3Client());
         return camelContext;
     }
 

--- a/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/src/test/java/org/apache/camel/example/AwsS3Test.java
+++ b/examples/aws/main-endpointdsl-aws2/aws2-s3-events-inject/src/test/java/org/apache/camel/example/AwsS3Test.java
@@ -22,49 +22,28 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.infra.aws.common.services.AWSService;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 /**
  * A unit test checking that Camel can store content into an Amazon S3 bucket.
  */
-@Testcontainers
 class AwsS3Test extends CamelMainTestSupport {
 
-    private static final String IMAGE = "localstack/localstack:0.13.3";
-
-    @Container
-    private final LocalStackContainer container = new LocalStackContainer(DockerImageName.parse(IMAGE))
-            .withServices(S3)
-            .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
+    @RegisterExtension
+    private static final AWSService AWS_SERVICE = AWSServiceFactory.createS3Service();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
-        s3.getConfiguration().setAmazonS3Client(
-                S3Client.builder()
-                .endpointOverride(container.getEndpointOverride(S3))
-                .credentialsProvider(
-                    StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
-                    )
-                )
-                .region(Region.of(container.getRegion()))
-                .build()
-        );
+        s3.getConfiguration().setAmazonS3Client(AWSSDKClientUtils.newS3Client());
         return camelContext;
     }
 

--- a/examples/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/pom.xml
+++ b/examples/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/pom.xml
@@ -88,9 +88,10 @@
         </dependency>
         <!-- for testing -->
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-kafka</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
+++ b/examples/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
@@ -24,61 +24,40 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.infra.aws.common.services.AWSService;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
+import org.apache.camel.test.infra.kafka.services.KafkaService;
+import org.apache.camel.test.infra.kafka.services.KafkaServiceFactory;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 /**
  * A unit test checking that Camel can poll data from a Kafka topic and put it into an Amazon S3 bucket.
  */
-@Testcontainers
 class KafkaAwsS3Test extends CamelMainTestSupport {
 
-    private static final String AWS_IMAGE = "localstack/localstack:0.13.3";
-    private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:6.2.2";
-
-    @Container
-    private final LocalStackContainer awsContainer = new LocalStackContainer(DockerImageName.parse(AWS_IMAGE))
-            .withServices(S3)
-            .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
-    @Container
-    private final KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE));
+    @RegisterExtension
+    private static final AWSService AWS_SERVICE = AWSServiceFactory.createS3Service();
+    @RegisterExtension
+    private static final KafkaService KAFKA_SERVICE = KafkaServiceFactory.createService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
-        s3.getConfiguration().setAmazonS3Client(
-                S3Client.builder()
-                .endpointOverride(awsContainer.getEndpointOverride(S3))
-                .credentialsProvider(
-                    StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(awsContainer.getAccessKey(), awsContainer.getSecretKey())
-                    )
-                )
-                .region(Region.of(awsContainer.getRegion()))
-                .build()
-        );
+        s3.getConfiguration().setAmazonS3Client(AWSSDKClientUtils.newS3Client());
         return camelContext;
     }
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         return asProperties(
-            "kafkaBrokers", String.format("%s:%d", kafkaContainer.getHost(), kafkaContainer.getMappedPort(9093))
+            "kafkaBrokers", KAFKA_SERVICE.getBootstrapServers()
         );
     }
 

--- a/examples/aws/main-endpointdsl-kafka-aws2-s3/pom.xml
+++ b/examples/aws/main-endpointdsl-kafka-aws2-s3/pom.xml
@@ -88,9 +88,10 @@
         </dependency>
         <!-- for testing -->
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-kafka</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/aws/main-endpointdsl-kafka-aws2-s3/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
+++ b/examples/aws/main-endpointdsl-kafka-aws2-s3/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
@@ -24,61 +24,40 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Component;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.infra.aws.common.services.AWSService;
+import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
+import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
+import org.apache.camel.test.infra.kafka.services.KafkaService;
+import org.apache.camel.test.infra.kafka.services.KafkaServiceFactory;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.util.PropertiesHelper.asProperties;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 /**
  * A unit test checking that Camel can poll data from a Kafka topic and put it into an Amazon S3 bucket.
  */
-@Testcontainers
 class KafkaAwsS3Test extends CamelMainTestSupport {
 
-    private static final String AWS_IMAGE = "localstack/localstack:0.13.3";
-    private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:6.2.2";
-
-    @Container
-    private final LocalStackContainer awsContainer = new LocalStackContainer(DockerImageName.parse(AWS_IMAGE))
-            .withServices(S3)
-            .waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
-    @Container
-    private final KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE));
+    @RegisterExtension
+    private static final AWSService AWS_SERVICE = AWSServiceFactory.createS3Service();
+    @RegisterExtension
+    private static final KafkaService KAFKA_SERVICE = KafkaServiceFactory.createService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
         CamelContext camelContext = super.createCamelContext();
         AWS2S3Component s3 = camelContext.getComponent("aws2-s3", AWS2S3Component.class);
-        s3.getConfiguration().setAmazonS3Client(
-                S3Client.builder()
-                .endpointOverride(awsContainer.getEndpointOverride(S3))
-                .credentialsProvider(
-                    StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(awsContainer.getAccessKey(), awsContainer.getSecretKey())
-                    )
-                )
-                .region(Region.of(awsContainer.getRegion()))
-                .build()
-        );
+        s3.getConfiguration().setAmazonS3Client(AWSSDKClientUtils.newS3Client());
         return camelContext;
     }
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
         return asProperties(
-            "kafkaBrokers", String.format("%s:%d", kafkaContainer.getHost(), kafkaContainer.getMappedPort(9093))
+            "kafkaBrokers", KAFKA_SERVICE.getBootstrapServers()
         );
     }
 

--- a/examples/aws/pom.xml
+++ b/examples/aws/pom.xml
@@ -53,15 +53,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>localstack</artifactId>
-            <version>${testcontainers-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-aws-v2</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/couchbase-log/pom.xml
+++ b/examples/couchbase-log/pom.xml
@@ -84,15 +84,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>couchbase</artifactId>
-            <version>${testcontainers-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-couchbase</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/debezium/pom.xml
+++ b/examples/debezium/pom.xml
@@ -99,27 +99,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>localstack</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-aws-v2</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-postgres</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>cassandra</artifactId>
-            <version>${testcontainers-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-cassandra</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/debezium/src/main/java/org/apache/camel/example/debezium/KinesisProducerToCassandra.java
+++ b/examples/debezium/src/main/java/org/apache/camel/example/debezium/KinesisProducerToCassandra.java
@@ -101,7 +101,7 @@ public final class KinesisProducerToCassandra {
                         // We just make sure we ONLY handle INSERT, UPDATE and DELETE and nothing else
                         .when(exchangeProperty("DBOperation").in("c", "u", "d"))
                         // Send query to Cassandra
-                        .recipientList(simple("cql:{{cassandra.host}}/{{cassandra.keyspace}}?cql=RAW(${header.CQLQuery})"))
+                        .recipientList(simple("cql:{{cassandra.node}}/{{cassandra.keyspace}}?cql=RAW(${header.CQLQuery})"))
                         .end();
             }
         };

--- a/examples/debezium/src/main/resources/application.properties
+++ b/examples/debezium/src/main/resources/application.properties
@@ -32,5 +32,5 @@ kinesis.accessKey = generated-access-key
 kinesis.secretKey = generated-secret-key
 kinesis.region = EU_CENTRAL_1
 
-cassandra.host = localhost:9042
+cassandra.node = localhost:9042
 cassandra.keyspace = dbzSink

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -91,15 +91,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>${testcontainers-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-kafka</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/kafka/src/main/java/org/apache/camel/example/kafka/MessagePublisherClient.java
+++ b/examples/kafka/src/main/java/org/apache/camel/example/kafka/MessagePublisherClient.java
@@ -119,7 +119,7 @@ public final class MessagePublisherClient {
     static void setUpKafkaComponent(CamelContext camelContext) {
         // setup kafka component with the brokers
         ComponentsBuilderFactory.kafka()
-                .brokers("{{kafka.host}}:{{kafka.port}}")
+                .brokers("{{kafka.brokers}}")
                 .register(camelContext, "kafka");
     }
 

--- a/examples/kafka/src/main/resources/application.properties
+++ b/examples/kafka/src/main/resources/application.properties
@@ -17,8 +17,7 @@
 
 ## Modify value of kafka.host and kafka.port before running application
 
-kafka.host=localhost
-kafka.port=9092
+kafka.brokers=localhost:9092
 
 # Producer properties
 producer.topic=TestLog

--- a/examples/mongodb/pom.xml
+++ b/examples/mongodb/pom.xml
@@ -83,15 +83,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>mongodb</artifactId>
-            <version>${testcontainers-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-mongodb</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/mongodb/src/test/java/org/apache/camel/example/mongodb/MongoDBTest.java
+++ b/examples/mongodb/src/test/java/org/apache/camel/example/mongodb/MongoDBTest.java
@@ -23,12 +23,11 @@ import com.mongodb.client.MongoClients;
 import io.restassured.response.Response;
 import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.spi.Registry;
+import org.apache.camel.test.infra.mongodb.services.MongoDBService;
+import org.apache.camel.test.infra.mongodb.services.MongoDBServiceFactory;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -38,22 +37,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A unit test checking that Camel can execute CRUD operations against MongoDB.
  */
-@Testcontainers
 class MongoDBTest extends CamelMainTestSupport {
-
-    private static final String IMAGE = "mongo:5.0";
 
     private static final String BASE_URI = "http://localhost:8081";
 
-    @Container
-    private final MongoDBContainer container = new MongoDBContainer(DockerImageName.parse(IMAGE));
+    @RegisterExtension
+    private static final MongoDBService SERVICE = MongoDBServiceFactory.createService();
 
     @Override
     protected void bindToRegistry(Registry registry) throws Exception {
-        registry.bind(
-            "myDb",
-            MongoClients.create(String.format("mongodb://%s:%d", container.getHost(), container.getMappedPort(27017)))
-        );
+        registry.bind("myDb", MongoClients.create(SERVICE.getReplicaSetUrl()));
     }
 
     @Test

--- a/examples/spring-pulsar/pom.xml
+++ b/examples/spring-pulsar/pom.xml
@@ -98,15 +98,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>pulsar</artifactId>
-            <version>${testcontainers-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-pulsar</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/spring-pulsar/src/main/resources/camel-common.xml
+++ b/examples/spring-pulsar/src/main/resources/camel-common.xml
@@ -29,10 +29,8 @@
     <!-- let Spring do its IoC stuff in this package -->
     <context:component-scan base-package="org.apache.camel.example.pulsar.common"/>
 
-    <!-- spring property placeholder, ignore resource not found as the file resource is for unit testing -->
-    <context:property-placeholder location="file:target/custom.properties"
-                                  ignore-resource-not-found="true"/>
-
+    <!-- Allow using placeholders -->
+    <bean id="placeholder" class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"/>
     <bean id="myTypeConverters" class="org.apache.camel.example.pulsar.common.TypeConverters"/>
 
     <!-- pulsar configurations -->
@@ -40,14 +38,14 @@
         <value>standalone</value>
     </util:set>
     <bean id="pulsarAdminHost" class="java.lang.String">
-        <constructor-arg value="${serviceUrl:http://localhost:8080}"/>
+        <constructor-arg value="${pulsar.admin.url:http://localhost:8080}"/>
     </bean>
     <bean id="autoconfig" class="org.apache.camel.component.pulsar.utils.AutoConfiguration">
         <constructor-arg ref="pulsarAdmin"/>
         <constructor-arg ref="clusters"/>
     </bean>
     <bean id="pulsarClientConfig" class="org.apache.pulsar.client.impl.conf.ClientConfigurationData">
-        <property name="serviceUrl" value="${brokerUrl:pulsar://localhost:6650}"/>
+        <property name="serviceUrl" value="${pulsar.broker.url:pulsar://localhost:6650}"/>
     </bean>
     <bean id="pulsarClientBuilder" class="org.apache.pulsar.client.impl.ClientBuilderImpl">
         <constructor-arg ref="pulsarClientConfig"/>

--- a/examples/spring-pulsar/src/test/java/org/apache/camel/example/SpringPulsarTest.java
+++ b/examples/spring-pulsar/src/test/java/org/apache/camel/example/SpringPulsarTest.java
@@ -16,19 +16,16 @@
  */
 package org.apache.camel.example;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.infra.pulsar.services.PulsarService;
+import org.apache.camel.test.infra.pulsar.services.PulsarServiceFactory;
 import org.apache.camel.test.spring.junit5.CamelSpringTestSupport;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.testcontainers.containers.PulsarContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import static org.apache.camel.example.pulsar.client.CamelClient.ENDPOINT_URI;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,23 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  *  A unit test checking that Camel can exchange messages with Apache Pulsar.
  */
-@Testcontainers
 class SpringPulsarTest extends CamelSpringTestSupport {
 
-    private static final String IMAGE = "apachepulsar/pulsar";
-
-    @Container
-    private final PulsarContainer container = new PulsarContainer(DockerImageName.parse(IMAGE));
-
-    @Override
-    protected void setupResources() throws Exception {
-        super.setupResources();
-        final String fileContent = String.format(
-            "serviceUrl=%s%nbrokerUrl=%s%n", container.getHttpServiceUrl(),
-            container.getPulsarBrokerUrl()
-        );
-        Files.writeString(Paths.get("target/custom.properties"), fileContent);
-    }
+    @RegisterExtension
+    private static final PulsarService SERVICE = PulsarServiceFactory.createService();
 
     @Override
     protected AbstractApplicationContext createApplicationContext() {

--- a/examples/vertx-kafka/pom.xml
+++ b/examples/vertx-kafka/pom.xml
@@ -99,15 +99,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
-            <version>${testcontainers-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers-version}</version>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-kafka</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/vertx-kafka/src/main/java/org/apache/camel/example/vertx/kafka/MessagePublisherClient.java
+++ b/examples/vertx-kafka/src/main/java/org/apache/camel/example/vertx/kafka/MessagePublisherClient.java
@@ -112,7 +112,7 @@ public final class MessagePublisherClient {
     static void setUpKafkaComponent(CamelContext camelContext) {
         // setup kafka component with the brokers using component DSL
         ComponentsBuilderFactory.vertxKafka()
-                .bootstrapServers("{{kafka.host}}:{{kafka.port}}")
+                .bootstrapServers("{{kafka.brokers}}")
                 .register(camelContext, "vertx-kafka");
     }
 }

--- a/examples/vertx-kafka/src/main/resources/application.properties
+++ b/examples/vertx-kafka/src/main/resources/application.properties
@@ -17,8 +17,7 @@
 
 ## Modify value of kafka.host and kafka.port before running application
 
-kafka.host=localhost
-kafka.port=9092
+kafka.brokers=localhost:9092
 
 # Producer properties
 producer.topic=TestLog

--- a/examples/vertx-kafka/src/test/java/org/apache/camel/example/vertx/kafka/VertxKafkaTest.java
+++ b/examples/vertx-kafka/src/test/java/org/apache/camel/example/vertx/kafka/VertxKafkaTest.java
@@ -22,13 +22,12 @@ import java.util.concurrent.TimeUnit;
 import org.apache.camel.CamelContext;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.infra.kafka.services.KafkaService;
+import org.apache.camel.test.infra.kafka.services.KafkaServiceFactory;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.camel.example.vertx.kafka.MessagePublisherClient.setUpKafkaComponent;
 import static org.apache.camel.util.PropertiesHelper.asProperties;
@@ -38,13 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A unit test checking that Camel can produce and consume messages to / from a Kafka broker using the Kafka Vertx
  * component.
  */
-@Testcontainers
 class VertxKafkaTest extends CamelTestSupport {
 
-    private static final String IMAGE = "confluentinc/cp-kafka:6.2.2";
-
-    @Container
-    private final KafkaContainer container = new KafkaContainer(DockerImageName.parse(IMAGE));
+    @RegisterExtension
+    private static final KafkaService SERVICE = KafkaServiceFactory.createService();
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
@@ -54,8 +50,7 @@ class VertxKafkaTest extends CamelTestSupport {
         // Override the host and port of the broker
         camelContext.getPropertiesComponent().setOverrideProperties(
             asProperties(
-                "kafka.host", container.getHost(),
-                "kafka.port", Integer.toString(container.getMappedPort(9093))
+                "kafka.brokers", SERVICE.getBootstrapServers()
             )
         );
         setUpKafkaComponent(camelContext);


### PR DESCRIPTION
## Motivation

The set of test components `camel-test-infra` allow to simplify a lot the integration tests and should be used instead of testcontainers directly.

## Modifications

* Replace the testcontainers dependencies with the `camel-test-infra` counterparts
* Replace the property `cassandra.host` with `cassandra.node` to avoid conflict with the system property added by `CassandraLocalContainerService`
* Configure `PGSimpleDataSource` in `createCamelContext()` instead of `ApplyChangesToPgSQLRouteBuilder#configure()` as it is more appropriate since `configure()` is meant to be used to build routes in debezium
* Replace placeholders of type `{{kafka.host}}:{{kafka.port}}` with `{{kafka.brokers}}` to ease the configuration
* Rely on the system properties added by `PulsarService` instead of the generated file `custom.properties` in spring-pulsar