### PR TITLE
CAMEL-17727: Add the docker-compose file in jbang-kafka-health

### DIFF
--- a/examples/jbang-kafka-health/README.adoc
+++ b/examples/jbang-kafka-health/README.adoc
@@ -25,7 +25,7 @@ and to start it again
 
 [source,sh]
 ----
-$ docker-compose stop
+$ docker-compose start
 ----
 
 And to shutdown when you no longer need the broker.
@@ -64,7 +64,7 @@ Then you can run this example using:
 
 [source,sh]
 ----
-$ camel run kafka-health.yaml --health
+$ camel run consumer.yaml producer.yaml --health
 ----
 
 Or run with JBang using the longer command line (without installing camel as app in JBang):

--- a/examples/jbang-kafka-health/consumer.yaml
+++ b/examples/jbang-kafka-health/consumer.yaml
@@ -4,6 +4,6 @@
     uri: "kamelet:kafka-not-secured-source"
     parameters:
       topic: "foobar"
-      bootstrapServers: 'localhost:29092'
+      bootstrapServers: 'localhost:9092'
     steps:
     - to: "log:info?showAll=true&multiline=true"

--- a/examples/jbang-kafka-health/docker-compose.yml
+++ b/examples/jbang-kafka-health/docker-compose.yml
@@ -1,0 +1,27 @@
+---
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.0.1
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:7.0.1
+    container_name: broker
+    ports:
+      # To learn about configuring Kafka for access across networks see
+      # https://www.confluent.io/blog/kafka-client-cannot-connect-to-broker-on-aws-on-docker-etc/
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1

--- a/examples/jbang-kafka-health/producer.yaml
+++ b/examples/jbang-kafka-health/producer.yaml
@@ -4,4 +4,4 @@
     uri: "kamelet:chuck-norris-source"
     steps:
     - log: "${body}"
-    - to: "kamelet:kafka-not-secured-sink?topic=foobar&bootstrapServers=localhost:29092"
+    - to: "kamelet:kafka-not-secured-sink?topic=foobar&bootstrapServers=localhost:9092"


### PR DESCRIPTION
## Motivation

Kafka cannot be launched following the readme as the docker-compose file is missing.

## Modifications:

* Add the missing docker-compose file
* Configure the default port of a Kafka broker in the routes
* Fix typos in the readme