### PR TITLE
CAMEL-17821 - Provide camel-debug in a profile

### DIFF
--- a/examples/main-xml/README.adoc
+++ b/examples/main-xml/README.adoc
@@ -37,6 +37,13 @@ Several IDEs are providing support for Camel Textual Route debugging. To enable 
 $ mvn camel:run -Pcamel.debug
 ----
 
+This profile can also be activated with camel.debug property set to true. For instance, by setting the property from command-line:
+
+[source,sh]
+----
+$ mvn camel:run -Dcamel.debug=true
+----
+
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please

--- a/examples/main-xml/README.adoc
+++ b/examples/main-xml/README.adoc
@@ -28,6 +28,15 @@ You can run this example using
 $ mvn camel:run
 ----
 
+=== How to configure for Camel Textual Route debugging
+
+Several IDEs are providing support for Camel Textual Route debugging. To enable this possibility, you need to launch this example with the profile `camel.debug`.
+
+[source,sh]
+----
+$ mvn camel:run -Pcamel.debug
+----
+
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please

--- a/examples/main-xml/pom.xml
+++ b/examples/main-xml/pom.xml
@@ -113,5 +113,21 @@
             </plugin>
         </plugins>
     </build>
-
+    <profiles>
+        <profile>
+            <id>camel.debug</id>
+            <activation>
+                <property>
+                    <name>camel.debug</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-debug</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/examples/main-yaml/README.adoc
+++ b/examples/main-yaml/README.adoc
@@ -37,6 +37,13 @@ Several IDEs are providing support for Camel Textual Route debugging. To enable 
 $ mvn camel:run -Pcamel.debug
 ----
 
+This profile can also be activated with camel.debug property set to true. For instance, by setting the property from command-line:
+
+[source,sh]
+----
+$ mvn camel:run -Dcamel.debug=true
+----
+
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please

--- a/examples/main-yaml/README.adoc
+++ b/examples/main-yaml/README.adoc
@@ -28,6 +28,15 @@ You can run this example using
 $ mvn camel:run
 ----
 
+=== How to configure for Camel Textual Route debugging
+
+Several IDEs are providing support for Camel Textual Route debugging. To enable this possibility, you need to launch this example with the profile `camel.debug`.
+
+[source,sh]
+----
+$ mvn camel:run -Pcamel.debug
+----
+
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please

--- a/examples/main-yaml/pom.xml
+++ b/examples/main-yaml/pom.xml
@@ -113,5 +113,22 @@
             </plugin>
         </plugins>
     </build>
-
+    
+    <profiles>
+        <profile>
+            <id>camel.debug</id>
+            <activation>
+                <property>
+                    <name>camel.debug</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-debug</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/examples/main/README.adoc
+++ b/examples/main/README.adoc
@@ -32,6 +32,15 @@ Then you can run this example using
 $ mvn camel:run
 ----
 
+=== How to configure for Camel Textual Route debugging
+
+Several IDEs are providing support for Camel Textual Route debugging. To enable this possibility, you need to launch this example with the profile `camel.debug`.
+
+[source,sh]
+----
+$ mvn camel:run -Pcamel.debug
+----
+
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please

--- a/examples/main/README.adoc
+++ b/examples/main/README.adoc
@@ -41,6 +41,13 @@ Several IDEs are providing support for Camel Textual Route debugging. To enable 
 $ mvn camel:run -Pcamel.debug
 ----
 
+This profile can also be activated with camel.debug property set to true. For instance, by setting the property from command-line:
+
+[source,sh]
+----
+$ mvn camel:run -Dcamel.debug=true
+----
+
 === Help and contributions
 
 If you hit any problem using Camel or have some feedback, then please

--- a/examples/main/pom.xml
+++ b/examples/main/pom.xml
@@ -63,10 +63,6 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-quartz</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-debug</artifactId>
-        </dependency>
 
         <!-- logging -->
         <dependency>
@@ -106,5 +102,21 @@
             </plugin>
         </plugins>
     </build>
-
+    <profiles>
+        <profile>
+            <id>camel.debug</id>
+            <activation>
+                <property>
+                    <name>camel.debug</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-debug</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Currently, Camel textual debugging requires having camel-debug in
dependencies. This is an extra dependency that we do not want at
runtime.

Previously:

* main java example is configured having it at runtime.
* main xml and yaml doesn't have it

I think a possible good practice is to add the dependency in a profile,
for instance named `camel.debug` which can be activated with the
property camel.debug set to true.

This would be nice to be done for all examples but maybe best to start
with the 3 more simple/important main (java), main-xml and main-yaml to
help starting discussion and see the feedback on it.

I think this is even more important for 3.16 as JMX is exposed by
default when the dependency is available.


~~wondering if a note should be added in readme of the examples~~ Edit: note added