### PR TITLE
CAMEL-18296: Align camel and camel-examples versions to avoid inconsistencies

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -172,7 +172,7 @@
         <jdk.version>11</jdk.version>
         <compiler.fork>false</compiler.fork>
 
-        <camel.version>3.19.0-SNAPSHOT</camel.version>
+        <camel.version>${project.version}</camel.version>
 
         <!-- Versions -->
         <arquillian-version>1.7.0.Alpha10</arquillian-version>


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/CAMEL-18296

## Motivation

The tag 3.18.0 depends on a snapshot version of Camel which is unexpected, we need to propose a way to prevent it in the next releases.

## Modifications:

* Align the versions of camel-examples with the version of camel to avoid inconsistencies 