### PR TITLE
Add MinIO component example with producer and consumer routes

### DIFF
--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -11,7 +11,7 @@ View the individual example READMEs for details.
 == Examples
 
 // examples: START
-Number of Examples: 91 (0 deprecated)
+Number of Examples: 92 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -83,10 +83,11 @@ Number of Examples: 91 (0 deprecated)
 
 | link:main-yaml/README.adoc[Main Yaml] (main-yaml) | Beginner | An example for showing standalone Camel using YAML
 
+| link:minio/README.adoc[MinIO] (minio) | Beginner | An example for showing Camel using MinIO Component
+
 | link:oaipmh/README.adoc[OAIPMH example] (oaipmh) | Beginner | An example with OAIPMH component
 
 | link:pojo-messaging/README.adoc[POJO Routing] (pojo-messaging) | Beginner | An example showing how to produce and consume messages from Camel endpoints using annotated POJOs
-    
 
 | link:routeloader/README.adoc[Routeloader] (routeloader) | Beginner | Example loading and compiling Java routes on startup
 

--- a/examples/minio/README.adoc
+++ b/examples/minio/README.adoc
@@ -1,0 +1,57 @@
+== Camel MinIO Example
+
+This example shows how to use Camel MinIO component to write and read objects in a bucket.
+
+The example has 2 routes :
+
+* the producer : put a file in a MinIO bucket
+* the consumer : poll a MinIO bucket and Log the content of the file.
+
+Notice how you can configure Camel in the `application.properties` file.
+
+Don't forget to add your MinIO Credentials and the bucket name.
+
+=== Run a MinIO instance
+
+You need to have an instance of MinIO server running locally.
+
+You can run it as a Docker container:
+
+[source,sh]
+----
+docker run \
+    -p 9000:9000 \
+    -p 9090:9090 \
+    -e "MINIO_ROOT_USER=xxxx" \
+    -e "MINIO_ROOT_PASSWORD=yyyyyyyy"  \
+    quay.io/minio/minio server /data  \
+    --console-address ":9090"
+----
+
+=== Build
+
+First compile the example by executing:
+
+[source,sh]
+----
+$ mvn compile
+----
+
+=== How to run
+
+You can run this example using
+
+[source,sh]
+----
+$ mvn camel:run
+----
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/examples/minio/pom.xml
+++ b/examples/minio/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.20.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-minio</artifactId>
+    <name>Camel :: Example :: MinIO</name>
+    <description>An example for showing Camel using MinIO Component</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <category>Beginner</category>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Add Camel BOM -->
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-bom</artifactId>
+                <version>${camel.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-main</artifactId>
+        </dependency>
+        <!-- we use the endpoint-dsl -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-endpointdsl</artifactId>
+        </dependency>
+        <!-- we use these camel components in this example -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-minio</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-timer</artifactId>
+        </dependency>
+
+        <!-- logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-version}</version>
+        </dependency>
+
+        <!-- testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-main-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-infra-minio</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- to run the application -->
+            <plugin>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-maven-plugin</artifactId>
+                <version>${camel.version}</version>
+                <configuration>
+                    <mainClass>org.apache.camel.example.MyApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/minio/src/main/java/org/apache/camel/example/MinioConsumer.java
+++ b/examples/minio/src/main/java/org/apache/camel/example/MinioConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
+
+/**
+ * To use the endpoint DSL then we must extend EndpointRouteBuilder instead of RouteBuilder
+ */
+public class MinioConsumer extends EndpointRouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from(minio("{{bucketName}}").delay(1000L).deleteAfterRead(false)).routeId("minio-consumer").log("the content is ${body}");
+    }
+}

--- a/examples/minio/src/main/java/org/apache/camel/example/MinioProducer.java
+++ b/examples/minio/src/main/java/org/apache/camel/example/MinioProducer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
+import org.apache.camel.component.minio.MinioConstants;
+
+/**
+ * To use the endpoint DSL then we must extend EndpointRouteBuilder instead of RouteBuilder
+ */
+public class MinioProducer extends EndpointRouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from(timer("fire").repeatCount("1"))
+                .routeId("minio-producer")
+                .process(exchange -> {
+                    exchange.getIn().setHeader(MinioConstants.OBJECT_NAME, "camel-content-type.txt");
+                    exchange.getIn().setHeader(MinioConstants.CONTENT_TYPE, "application/text");
+                    exchange.getIn().setBody("Camel MinIO rocks!");
+                })
+                .to(minio("{{bucketName}}").autoCreateBucket(true));
+    }
+}

--- a/examples/minio/src/main/java/org/apache/camel/example/MyApplication.java
+++ b/examples/minio/src/main/java/org/apache/camel/example/MyApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import org.apache.camel.main.Main;
+
+/**
+ * Main class that boot the Camel application
+ */
+public final class MyApplication {
+
+    private MyApplication() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        // use Camels Main class
+        Main main = new Main(MyApplication.class);
+        // now keep the application running until the JVM is terminated (ctrl + c or sigterm)
+        main.run(args);
+    }
+
+}

--- a/examples/minio/src/main/resources/application.properties
+++ b/examples/minio/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# here you can configure options on camel main
+# https://camel.apache.org/components/next/others/main.html
+camel.main.name = MinIO-Camel
+
+# properties used by the component
+camel.component.minio.accessKey=xxxx
+camel.component.minio.secretKey=yyyyyyyy
+camel.component.minio.endpoint=localhost
+camel.component.minio.proxyPort=9000
+
+# properties used in the routes
+bucketName=camel

--- a/examples/minio/src/main/resources/logback.xml
+++ b/examples/minio/src/main/resources/logback.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/examples/minio/src/test/java/org/apache/camel/example/MainMinioTest.java
+++ b/examples/minio/src/test/java/org/apache/camel/example/MainMinioTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example;
+
+import io.minio.MinioClient;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.component.minio.MinioComponent;
+import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.infra.minio.services.MinioService;
+import org.apache.camel.test.infra.minio.services.MinioServiceFactory;
+import org.apache.camel.test.main.junit5.CamelMainTestSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MainMinioTest extends CamelMainTestSupport {
+
+    @RegisterExtension
+    private static final MinioService MINIO_SERVICE = MinioServiceFactory.createService();
+
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext camelContext = super.createCamelContext();
+        MinioComponent minio = camelContext.getComponent("minio", MinioComponent.class);
+
+        minio.getConfiguration().setMinioClient(MinioClient.builder()
+                .endpoint("http://" + MINIO_SERVICE.host(), MINIO_SERVICE.port(), false)
+                .credentials(MINIO_SERVICE.accessKey(), MINIO_SERVICE.secretKey())
+                .build());
+        return camelContext;
+    }
+
+    @Test
+    void should_consume_and_poll_minio_bucket() {
+
+        NotifyBuilder notify = new NotifyBuilder(context).fromRoute("minio-consumer").whenCompleted(1).create();
+        assertTrue(
+                notify.matches(20, TimeUnit.SECONDS), "1 message should be completed"
+        );
+
+    }
+
+    @Test
+    void should_produce_and_put_in_minio_bucket() {
+
+        NotifyBuilder notify = new NotifyBuilder(context).fromRoute("minio-producer").whenCompleted(1).create();
+        assertTrue(
+                notify.matches(20, TimeUnit.SECONDS), "1 file should be created"
+        );
+
+    }
+
+    @Override
+    protected void configure(MainConfigurationProperties configuration) {
+        configuration.addRoutesBuilder(MinioConsumer.class);
+        configuration.addRoutesBuilder(MinioProducer.class);
+    }
+
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -135,6 +135,7 @@
         <module>main-yaml</module>
         <module>management</module>
         <module>mapstruct</module>
+        <module>minio</module>
         <module>mongodb</module>
         <module>netty-custom-correlation</module>
         <module>oaipmh</module>


### PR DESCRIPTION
# Description:

Add an example to show how to use the Camel MinIO component with Endpoint DSL configuration to write and read objects in a bucket. 

This example is inspired by the aws-s3 example.
