### PR TITLE
Fix main build by using release configuration for maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,8 +259,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin-version}</version>
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                	<release>${jdk.version}</release>
                     <maxmem>512M</maxmem>
                     <fork>${compiler.fork}</fork>
                 </configuration>


### PR DESCRIPTION
main branch currently failing with:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project camel-example-aggregate-dist: Compilation failure
Error:  /home/runner/work/camel-examples/camel-examples/aggregate-dist/src/main/java/org/apache/camel/example/Application.java:[72,36] method references are not supported in -source 7
Error:    (use -source 8 or higher to enable method references)
```