### PR TITLE
Fix compilation due to API break with Camel 4.11 and 4.10

### DIFF
--- a/as2/src/main/java/org/apache/camel/example/as2/ProvisionAS2ComponentCrypto.java
+++ b/as2/src/main/java/org/apache/camel/example/as2/ProvisionAS2ComponentCrypto.java
@@ -59,7 +59,7 @@ public class ProvisionAS2ComponentCrypto implements CamelContextAware {
         configuration.setSigningAlgorithm(AS2SignatureAlgorithm.SHA512WITHRSA);
         configuration.setSigningCertificateChain(certList.toArray(new Certificate[0]));
         configuration.setSigningPrivateKey(signingKP.getPrivate());
-        configuration.setSignedReceiptMicAlgorithms(new String[] {"sha1", "md5"});
+        configuration.setSignedReceiptMicAlgorithms("sha1,md5");
         configuration.setEncryptingAlgorithm(AS2EncryptionAlgorithm.AES128_CBC);
         configuration.setEncryptingCertificateChain(certList.toArray(new Certificate[0]));
         configuration.setDecryptingPrivateKey(decryptingKP.getPrivate());

--- a/debezium/src/test/java/org/apache/camel/example/debezium/DebeziumTest.java
+++ b/debezium/src/test/java/org/apache/camel/example/debezium/DebeziumTest.java
@@ -31,8 +31,8 @@ import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.test.infra.aws.common.services.AWSService;
 import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
 import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
-import org.apache.camel.test.infra.cassandra.services.CassandraLocalContainerService;
 import org.apache.camel.test.infra.cassandra.services.CassandraService;
+import org.apache.camel.test.infra.cassandra.services.CassandraServiceFactory;
 import org.apache.camel.test.infra.postgres.services.PostgresLocalContainerService;
 import org.apache.camel.test.infra.postgres.services.PostgresService;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.CassandraContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -62,7 +61,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DebeziumTest extends CamelMainTestSupport {
 
     private static final String PGSQL_IMAGE = "debezium/example-postgres:2.3.2.Final";
-    private static final String CASSANDRA_IMAGE = "cassandra:4.0.1";
 
     private static final String SOURCE_DB_NAME = "debezium-db";
     private static final String SOURCE_DB_SCHEMA = "inventory";
@@ -80,11 +78,7 @@ class DebeziumTest extends CamelMainTestSupport {
                 .withPassword(SOURCE_DB_PASSWORD)
     );
     @RegisterExtension
-    private static final CassandraService CASSANDRA_SERVICE = new CassandraLocalContainerService(
-        new CassandraContainer<>(CASSANDRA_IMAGE)
-            .withInitScript("org/apache/camel/example/debezium/db-init.cql")
-    );
-
+    private static final CassandraService CASSANDRA_SERVICE = CassandraServiceFactory.createLocalService("org/apache/camel/example/debezium/db-init.cql");
 
     @BeforeEach
     void init() throws IOException {


### PR DESCRIPTION
API break introduced with
https://github.com/apache/camel/commit/5d964ff96680d58985250701352de1a384ab6806 and https://github.com/apache/camel/commit/b69f24882d0e57110e09d918235fabdba734d7a8