### PR TITLE
Fix LoadBalancerTest related to API break in Camel 4.10 and 4.8.3

### DIFF
--- a/loadbalancing/src/main/resources/META-INF/spring/camel-route-context-loadbalancer.xml
+++ b/loadbalancing/src/main/resources/META-INF/spring/camel-route-context-loadbalancer.xml
@@ -16,10 +16,10 @@
              in case of failure -->
         <route id="loadbalancer">
             <from uri="direct:loadbalance"/>
-            <loadBalance inheritErrorHandler="false">
-                <failoverLoadBalancer roundRobin="true"/>
-                <to uri="mina:tcp://localhost:9991?sync=true"/>
-                <to uri="mina:tcp://localhost:9992?sync=true"/>
+            <loadBalance>
+                <failoverLoadBalancer roundRobin="true" inheritErrorHandler="false"/>
+                <to uri="mina:tcp://localhost:9991?sync=true&amp;objectCodecPattern=*"/>
+                <to uri="mina:tcp://localhost:9992?sync=true&amp;objectCodecPattern=*"/>
             </loadBalance>
             <log message="${body}"/>
         </route>

--- a/loadbalancing/src/main/resources/META-INF/spring/camel-route-template-mina.xml
+++ b/loadbalancing/src/main/resources/META-INF/spring/camel-route-template-mina.xml
@@ -9,7 +9,7 @@
         <routeTemplate id="route-template-mina">
             <templateParameter name="host"/>
             <route>
-                <from uri="mina:tcp://{{host}}"/>
+                <from uri="mina:tcp://{{host}}?objectCodecPattern=*"/>
                 <setHeader name="minaServer">
                     <constant>{{host}}</constant>
                 </setHeader>


### PR DESCRIPTION
inheritErrorHandler attribute
https://camel.apache.org/manual/camel-4x-upgrade-guide-4_10.html#_xml_dsl_changes

it avoids this error:
```
java.lang.IllegalStateException: Failed to load ApplicationContext for [MergedContextConfiguration@3aefae67 testClass = org.apache.camel.example.LoadBalancingTest, locations = ["classpath:/org/apache/camel/example/test-camel-context.xml"], classes = [], contextInitializerClasses = [], activeProfiles = [], propertySourceDescriptors = [], propertySourceProperties = [], contextCustomizers = [org.springframework.test.context.support.DynamicPropertiesContextCustomizer@0], contextLoader = org.apache.camel.test.spring.junit5.CamelSpringTestContextLoader, parent = null]
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:180)
	at org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:130)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependencies(DependencyInjectionTestExecutionListener.java:155)
	at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:111)
	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:260)
	at org.springframework.test.context.junit.jupiter.SpringExtension.postProcessTestInstance(SpringExtension.java:160)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
	at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
	at java.base/java.util.Optional.orElseGet(Unknown Source)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
Caused by: org.springframework.beans.factory.parsing.BeanDefinitionParsingException: Configuration problem: Failed to import bean definitions from URL location [classpath:/META-INF/spring/camel-route-context-loadbalancer.xml]
Offending resource: class path resource [org/apache/camel/example/test-camel-context.xml]
	at org.springframework.beans.factory.parsing.FailFastProblemReporter.error(FailFastProblemReporter.java:72)
	at org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:119)
	at org.springframework.beans.factory.parsing.ReaderContext.error(ReaderContext.java:104)
	at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.importBeanDefinitionResource(DefaultBeanDefinitionDocumentReader.java:240)
	at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseDefaultElement(DefaultBeanDefinitionDocumentReader.java:191)
	at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.parseBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:176)
	at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.doRegisterBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:150)
	at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.registerBeanDefinitions(DefaultBeanDefinitionDocumentReader.java:96)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.registerBeanDefinitions(XmlBeanDefinitionReader.java:520)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:400)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:347)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:319)
	at org.apache.camel.test.spring.junit5.CamelSpringTestContextLoader.loadBeanDefinitions(CamelSpringTestContextLoader.java:174)
	at org.apache.camel.test.spring.junit5.CamelSpringTestContextLoader.loadBeanDefinitions(CamelSpringTestContextLoader.java:164)
	at org.apache.camel.test.spring.junit5.CamelSpringTestContextLoader.loadContext(CamelSpringTestContextLoader.java:72)
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:225)
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:152)
	... 19 more
Caused by: org.springframework.beans.factory.xml.XmlBeanDefinitionStoreException: Line 19 in XML document from class path resource [META-INF/spring/camel-route-context-loadbalancer.xml] is invalid
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:411)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:347)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.loadBeanDefinitions(XmlBeanDefinitionReader.java:319)
	at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions(AbstractBeanDefinitionReader.java:184)
	at org.springframework.beans.factory.support.AbstractBeanDefinitionReader.loadBeanDefinitions(AbstractBeanDefinitionReader.java:220)
	at org.springframework.beans.factory.xml.DefaultBeanDefinitionDocumentReader.importBeanDefinitionResource(DefaultBeanDefinitionDocumentReader.java:234)
	... 32 more
Caused by: org.xml.sax.SAXParseException; lineNumber: 19; columnNumber: 54; cvc-complex-type.3.2.2: Attribute 'inheritErrorHandler' is not allowed to appear in element 'loadBalance'.
	at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator$XSIErrorReporter.reportError(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.reportSchemaError(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.processAttributes(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.handleStartElement(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.startElement(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.scanStartElement(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(Unknown Source)
	at org.springframework.beans.factory.xml.DefaultDocumentLoader.loadDocument(DefaultDocumentLoader.java:77)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadDocument(XmlBeanDefinitionReader.java:441)
	at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:399)
	... 37 more
```

but there is still this error:
```
org.opentest4j.AssertionFailedError: 4 messages should be completed ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:63)
	at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:36)
	at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:214)
	at org.apache.camel.example.LoadBalancingTest.should_support_load_balancing(LoadBalancingTest.java:52)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
```

