### PR TITLE
Remove usage of deprecated method

### DIFF
--- a/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
+++ b/aws/main-endpointdsl-kafka-aws2-s3-restarting-policy/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
@@ -29,6 +29,7 @@ import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
 import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
 import org.apache.camel.test.infra.kafka.services.KafkaService;
 import org.apache.camel.test.infra.kafka.services.KafkaServiceFactory;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -55,10 +56,10 @@ class KafkaAwsS3Test extends CamelMainTestSupport {
     }
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties(
-            "kafkaBrokers", KAFKA_SERVICE.getBootstrapServers()
-        );
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("kafkaBrokers", KAFKA_SERVICE.getBootstrapServers());
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/aws/main-endpointdsl-kafka-aws2-s3/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
+++ b/aws/main-endpointdsl-kafka-aws2-s3/src/test/java/org/apache/camel/example/KafkaAwsS3Test.java
@@ -29,6 +29,7 @@ import org.apache.camel.test.infra.aws2.clients.AWSSDKClientUtils;
 import org.apache.camel.test.infra.aws2.services.AWSServiceFactory;
 import org.apache.camel.test.infra.kafka.services.KafkaService;
 import org.apache.camel.test.infra.kafka.services.KafkaServiceFactory;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -55,10 +56,10 @@ class KafkaAwsS3Test extends CamelMainTestSupport {
     }
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties(
-            "kafkaBrokers", KAFKA_SERVICE.getBootstrapServers()
-        );
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("kafkaBrokers", KAFKA_SERVICE.getBootstrapServers());
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/couchbase-log/src/test/java/org/apache/camel/example/CouchbaseTest.java
+++ b/couchbase-log/src/test/java/org/apache/camel/example/CouchbaseTest.java
@@ -34,6 +34,7 @@ import org.apache.camel.component.couchbase.CouchbaseConstants;
 import org.apache.camel.main.MainConfigurationProperties;
 import org.apache.camel.test.infra.couchbase.services.CouchbaseService;
 import org.apache.camel.test.infra.couchbase.services.CouchbaseServiceFactory;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -80,14 +81,15 @@ class CouchbaseTest extends CamelMainTestSupport {
     }
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties(
-            "couchbase.host", SERVICE.getHostname(),
-            "couchbase.port", Integer.toString(SERVICE.getPort()),
-            "couchbase.username", SERVICE.getUsername(),
-            "couchbase.password", SERVICE.getPassword(),
-            "couchbase.bucket", BUCKET
-        );
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties(
+                "couchbase.host", SERVICE.getHostname(),
+                "couchbase.port", Integer.toString(SERVICE.getPort()),
+                "couchbase.username", SERVICE.getUsername(),
+                "couchbase.password", SERVICE.getPassword(),
+                "couchbase.bucket", BUCKET);
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/csimple-joor/src/test/java/org/apache/camel/example/CSimpleJOORTest.java
+++ b/csimple-joor/src/test/java/org/apache/camel/example/CSimpleJOORTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.example;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -32,10 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class CSimpleJOORTest extends CamelMainTestSupport {
 
-
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties("myPeriod", Integer.toString(500));
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("myPeriod", Integer.toString(500));
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/csimple/src/test/java/org/apache/camel/example/CSimpleTest.java
+++ b/csimple/src/test/java/org/apache/camel/example/CSimpleTest.java
@@ -18,6 +18,7 @@ package org.apache.camel.example;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CSimpleTest extends CamelMainTestSupport {
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties("myPeriod", Integer.toString(500));
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("myPeriod", Integer.toString(500));
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/debezium/src/test/java/org/apache/camel/example/debezium/DebeziumTest.java
+++ b/debezium/src/test/java/org/apache/camel/example/debezium/DebeziumTest.java
@@ -35,6 +35,7 @@ import org.apache.camel.test.infra.cassandra.services.CassandraService;
 import org.apache.camel.test.infra.cassandra.services.CassandraServiceFactory;
 import org.apache.camel.test.infra.postgres.services.PostgresLocalContainerService;
 import org.apache.camel.test.infra.postgres.services.PostgresService;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,15 +107,14 @@ class DebeziumTest extends CamelMainTestSupport {
     }
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        // Override the host and port of the broker
-        return asProperties(
-            "debezium.postgres.databaseHostName", POSTGRES_SERVICE.host(),
-            "debezium.postgres.databasePort", Integer.toString(POSTGRES_SERVICE.port()),
-            "debezium.postgres.databaseUser", SOURCE_DB_USERNAME,
-            "debezium.postgres.databasePassword", SOURCE_DB_PASSWORD,
-            "cassandra.node", String.format("%s:%d", CASSANDRA_SERVICE.getCassandraHost(), CASSANDRA_SERVICE.getCQL3Port())
-        );
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("debezium.postgres.databaseHostName", POSTGRES_SERVICE.host(),
+                "debezium.postgres.databasePort", Integer.toString(POSTGRES_SERVICE.port()),
+                "debezium.postgres.databaseUser", SOURCE_DB_USERNAME,
+                "debezium.postgres.databasePassword", SOURCE_DB_PASSWORD,
+                "cassandra.node", String.format("%s:%d", CASSANDRA_SERVICE.getCassandraHost(), CASSANDRA_SERVICE.getCQL3Port()));
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/ftp/src/test/java/org/apache/camel/example/ftp/FtpTest.java
+++ b/ftp/src/test/java/org/apache/camel/example/ftp/FtpTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.apache.ftpserver.FtpServer;
 import org.apache.ftpserver.FtpServerFactory;
@@ -87,12 +88,13 @@ class FtpTest extends CamelMainTestSupport {
     }
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties(
-            "ftp.port", Integer.toString(PORT),
-            "ftp.username", "admin",
-            "ftp.password", "admin"
-        );
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties(
+                "ftp.port", Integer.toString(PORT),
+                "ftp.username", "admin",
+                "ftp.password", "admin");
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/main-endpointdsl/src/test/java/org/apache/camel/example/MainEndpointDSLTest.java
+++ b/main-endpointdsl/src/test/java/org/apache/camel/example/MainEndpointDSLTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MainEndpointDSLTest extends CamelMainTestSupport {
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties("myPeriod", Integer.toString(500));
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("myPeriod", Integer.toString(500));
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/main-health/src/test/java/org/apache/camel/example/MainHealthTest.java
+++ b/main-health/src/test/java/org/apache/camel/example/MainHealthTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MainHealthTest extends CamelMainTestSupport {
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties("myPeriod", Integer.toString(500));
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("myPeriod", Integer.toString(500));
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Override

--- a/main-joor/src/test/java/org/apache/camel/example/MainJOORTest.java
+++ b/main-joor/src/test/java/org/apache/camel/example/MainJOORTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MainJOORTest extends CamelMainTestSupport {
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties("myPeriod", Integer.toString(500));
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("myPeriod", Integer.toString(500));
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test

--- a/main-tiny/src/test/java/org/apache/camel/example/MainTinyTest.java
+++ b/main-tiny/src/test/java/org/apache/camel/example/MainTinyTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.main.MainConfigurationProperties;
+import org.apache.camel.test.junit5.CamelContextConfiguration;
 import org.apache.camel.test.main.junit5.CamelMainTestSupport;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MainTinyTest extends CamelMainTestSupport {
 
     @Override
-    protected Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties("myPeriod", Integer.toString(500));
+    public void configureContext(CamelContextConfiguration camelContextConfiguration) {
+        super.configureContext(camelContextConfiguration);
+        Properties overridenProperties = asProperties("myPeriod", Integer.toString(500));
+        camelContextConfiguration.withUseOverridePropertiesWithPropertiesComponent(overridenProperties);
     }
 
     @Test


### PR DESCRIPTION
useOverridePropertiesWithPropertiesComponent in Tests

it was deprecated in Camel 4.7.0
https://github.com/apache/camel/blob/0a8fc9314ccd6571e8a5686f38d381e728ab1375/components/camel-test/camel-test-junit5/src/main/java/org/apache/camel/test/junit5/AbstractTestSupport.java#L339-L342