### PR TITLE
Fix jooQ test - adapt to commons-dbcp2

### DIFF
--- a/jooq/pom.xml
+++ b/jooq/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>hsqldb</artifactId>
             <version>${hsqldb-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>${commons-dbcp2-version}</version>
+        </dependency>
 
         <!-- for testing -->
         <dependency>

--- a/jooq/src/main/resources/META-INF/spring/jooq-spring.xml
+++ b/jooq/src/main/resources/META-INF/spring/jooq-spring.xml
@@ -26,10 +26,10 @@
     <context:property-placeholder location="classpath:config.properties"
                                   xmlns:context="http://www.springframework.org/schema/context"/>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
+    <bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
         <property name="url" value="${db.url}"/>
         <property name="driverClassName" value="${db.driver}"/>
-        <property name="maxActive" value="${db.pool.maxActive}" />
+        <property name="maxTotal" value="${db.pool.maxTotal}" />
         <property name="maxIdle" value="${db.pool.maxIdle}" />
         <property name="username" value="${db.username}"/>
         <property name="password" value="${db.password}"/>

--- a/jooq/src/main/resources/config.properties
+++ b/jooq/src/main/resources/config.properties
@@ -17,7 +17,7 @@
 #Database Configuration
 db.driver=org.hsqldb.jdbcDriver
 db.url=jdbc:hsqldb:file:${basedir}/target/db;shutdown=true
-db.pool.maxActive=50
+db.pool.maxTotal=50
 db.pool.maxIdle=20
 db.username=sa
 db.password=


### PR DESCRIPTION
changes from upstream:
https://github.com/apache/camel/commit/74ddde4df61eff65b3f28d18bc7e8eb9826e156f#diff-1f13da1b3a3f9866797ee7599afcfc253b533788a5f5046992439d520155e8fa
* note that previously the commons-dbcp was a runtime dependencies, when upgrading to dbcp2, it has been moved to test dependency, which means that when using it, now requires to explicitly declare it