### PR TITLE
[NOT WORKING] Upgrade Cassandra driver and update example

### DIFF
--- a/cassandra-kubernetes/README.adoc
+++ b/cassandra-kubernetes/README.adoc
@@ -47,7 +47,7 @@ cassandra-1                                1/1       Running   0          2h
 You can also verify the health of your cluster by running
 
 ----
-$ kubectl exec <pod_name> -it nodetool status
+$ kubectl exec <pod_name> -- nodetool status
 Datacenter: DC1-K8Demo
 ======================
 Status=Up/Down

--- a/cassandra-kubernetes/pom.xml
+++ b/cassandra-kubernetes/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <category>Database</category>
         <!-- dependency versions -->
-        <cassandra.driver.version>4.0.0</cassandra.driver.version>
+        <cassandra.driver.version>4.19.2</cassandra.driver.version>
         <main.class>org.apache.camel.spring.Main</main.class>
     </properties>
 
@@ -74,8 +74,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
-            <artifactId>cassandra-driver-core</artifactId>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>java-driver-core</artifactId>
             <version>${cassandra.driver.version}</version>
             <exclusions>
                 <exclusion>

--- a/cassandra-kubernetes/src/main/java/org/apache/camel/example/kubernetes/jkube/CqlPopulateBean.java
+++ b/cassandra-kubernetes/src/main/java/org/apache/camel/example/kubernetes/jkube/CqlPopulateBean.java
@@ -16,8 +16,7 @@
  */
 package org.apache.camel.example.kubernetes.jkube;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +25,7 @@ public class CqlPopulateBean {
     private static final Logger log = LoggerFactory.getLogger(CqlPopulateBean.class);
 
     public void populate() {
-        try (Cluster cluster = Cluster.builder().addContactPoint("cassandra").build();
-            Session session = cluster.connect()) {
+        try (CqlSession session = CqlSession.builder()/*.addContactEndPoint("cassandra")*/.build();) {
             session.execute("CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1};");
             session.execute("CREATE TABLE IF NOT EXISTS test.users ( id int primary key, name text );");
             session.execute("INSERT INTO test.users (id,name) VALUES (1, 'oscerd') IF NOT EXISTS;");


### PR DESCRIPTION
* cassandra driver has been relocated (2 times!) and the APi has been modified. there is no more Cluster, all is coming from the top-lvel CqlSession directly
* update command inreadme to avoid: error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead

this is still not working, when following the steps, in the pod there is this error:
```
Failed to pull image
"example/camel-example-cassandra-kubernetes:latest": Error response from
daemon: pull access denied for
example/camel-example-cassandra-kubernetes, repository does not exist or
may require 'docker login': denied: requested access to the resource is
denied
```