### PR TITLE
Remove maven-eclipse-plugin from plugin management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,22 +288,6 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin-version}</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-eclipse-plugin</artifactId>
-                    <version>2.10</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.camel</groupId>
-                            <artifactId>camel-buildtools</artifactId>
-                            <version>${camel.version}</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <downloadSources>true</downloadSources>
-                        <downloadJavadocs>false</downloadJavadocs>
-                    </configuration>
-                </plugin>
 
                 <plugin>
                     <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
as it is unmaintained since 2015. Recommendation is to rely on m2e (Maven To Eclipse)