### PR TITLE
Deprecate example relate to csimple

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,9 +60,9 @@ Number of Examples: 72 (0 deprecated)
 
 | link:console/README.adoc[Console] (console) | Beginner | An example that reads input from the console
 
-| link:csimple/README.adoc[Csimple] (csimple) | Beginner | Shows using compiled simple language
+| link:csimple/README.adoc[Csimple] (csimple) | Beginner | (deprecated) Shows using compiled simple language
 
-| link:csimple-joor/README.adoc[Csimple Joor] (csimple-joor) | Beginner | Shows using compiled simple language with jOOR compiler
+| link:csimple-joor/README.adoc[Csimple Joor] (csimple-joor) | Beginner | (deprecated) Shows using compiled simple language with jOOR compiler
 
 | link:spring/README.adoc[Spring] (spring) | Beginner | An example showing how to work with Camel and Spring
 

--- a/csimple-joor/pom.xml
+++ b/csimple-joor/pom.xml
@@ -30,8 +30,8 @@
 
     <artifactId>camel-example-csimple-joor</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: Example :: Compiled Simple jOOR</name>
-    <description>Shows using compiled simple language with jOOR compiler</description>
+    <name>Camel :: Example :: Compiled Simple jOOR (deprecated)</name>
+    <description>(deprecated) Shows using compiled simple language with jOOR compiler</description>
 
     <properties>
         <category>Beginner</category>

--- a/csimple/pom.xml
+++ b/csimple/pom.xml
@@ -30,8 +30,8 @@
 
     <artifactId>camel-example-csimple</artifactId>
     <packaging>jar</packaging>
-    <name>Camel :: Example :: Compiled Simple</name>
-    <description>Shows using compiled simple language</description>
+    <name>Camel :: Example :: Compiled Simple (deprecated)</name>
+    <description>Shows using compiled simple language (deprecated)</description>
 
     <properties>
         <category>Beginner</category>


### PR DESCRIPTION
as CSimple has been deprecated in 4.19