### PR TITLE
Make existing couchbase test passing

### DIFF
--- a/couchbase-log/src/main/java/org/apache/camel/example/MyRouteBuilder.java
+++ b/couchbase-log/src/main/java/org/apache/camel/example/MyRouteBuilder.java
@@ -23,7 +23,7 @@ public class MyRouteBuilder extends RouteBuilder {
     @Override
     public void configure() throws Exception {
 
-        from("couchbase:http://{{couchbase.host}}:{{couchbase.port}}?bucket={{couchbase.bucket}}&username={{couchbase.username}}&password={{couchbase.password}}&consumerProcessedStrategy={{couchbase.consumerProcessedStrategy}}")
+        from("couchbase:http://{{couchbase.host}}:{{couchbase.port}}?bucket={{couchbase.bucket}}&username={{couchbase.username}}&password={{couchbase.password}}&consumerProcessedStrategy={{couchbase.consumerProcessedStrategy}}&useView=true&connectionString={{couchbase.connectionString}}")
           .to("log:info");
 
     }

--- a/couchbase-log/src/main/resources/application.properties
+++ b/couchbase-log/src/main/resources/application.properties
@@ -21,6 +21,7 @@ camel.main.name = LogCouchbase
 
 couchbase.host=localhost
 couchbase.port=8091
+couchbase.connectionString=couchbase://localhost:11210
 couchbase.username=admin
 couchbase.password=password
 couchbase.bucket=beer-sample

--- a/couchbase-log/src/test/java/org/apache/camel/example/CouchbaseTest.java
+++ b/couchbase-log/src/test/java/org/apache/camel/example/CouchbaseTest.java
@@ -26,6 +26,7 @@ import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.manager.bucket.BucketSettings;
 import com.couchbase.client.java.manager.bucket.BucketType;
+import com.couchbase.client.java.manager.bucket.StorageBackend;
 import com.couchbase.client.java.manager.view.DesignDocument;
 import com.couchbase.client.java.manager.view.View;
 import com.couchbase.client.java.view.DesignDocumentNamespace;
@@ -68,7 +69,7 @@ class CouchbaseTest extends CamelMainTestSupport {
             )
         );
         CLUSTER.buckets().createBucket(
-                BucketSettings.create(BUCKET).bucketType(BucketType.COUCHBASE).flushEnabled(true));
+                BucketSettings.create(BUCKET).bucketType(BucketType.COUCHBASE).storageBackend(StorageBackend.COUCHSTORE).flushEnabled(true));
         CLUSTER.bucket(BUCKET).viewIndexes().upsertDesignDocument(designDoc, DesignDocumentNamespace.PRODUCTION);
     }
 
@@ -83,7 +84,9 @@ class CouchbaseTest extends CamelMainTestSupport {
     @Override
     public void configureContext(CamelContextConfiguration camelContextConfiguration) {
         super.configureContext(camelContextConfiguration);
+        System.out.println("#### " + SERVICE.getConnectionString());
         Properties overridenProperties = asProperties(
+                "couchbase.connectionString", SERVICE.getConnectionString(),
                 "couchbase.host", SERVICE.hostname(),
                 "couchbase.port", Integer.toString(SERVICE.port()),
                 "couchbase.username", SERVICE.username(),


### PR DESCRIPTION
* use legacy and deprecated useView https://github.com/apache/camel/commit/fc0232611226784db75c75718969e22e86fb8424
* specify connectionString https://github.com/apache/camel/commit/6c2f45894a0d74ed353a5921111e2d9a37447e4b#diff-4eb6639d76f2cd4d5d9bcfc178e7c869a13b0b9533f96e7a6dc32102cd44ede6

the test is passing but there are a lot of errors and stacktraces in the log. Also in camel core, the integration tests are failing, see https://issues.apache.org/jira/browse/CAMEL-23625

I opened https://issues.apache.org/jira/browse/CAMEL-23626 to migrate away from the deprecate "View"