### PR TITLE
Add Spring Boot genai-observability example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
         <module>spring</module>
         <module>spring-pulsar</module>
         <module>spring-xquery</module>
+        <module>spring-boot</module>
         <module>telegram</module>
         <module>timer</module>
         <module>transformer-demo</module>

--- a/spring-boot/genai-observability/README.adoc
+++ b/spring-boot/genai-observability/README.adoc
@@ -1,0 +1,68 @@
+= Spring Boot GenAI Observability Example
+
+== Introduction
+
+This example demonstrates *GenAI observability* in Apache Camel 4.23+ with Spring Boot:
+OpenTelemetry `gen_ai.*` span attributes and Micrometer metrics for `langchain4j-chat`
+LLM calls, visualized with Prometheus and VictoriaTraces.
+
+It pairs with the community blog post *GenAI Observability with Spring Boot and the Camel Observability Stack*.
+
+=== Prerequisites
+
+* Java 17+
+* Maven 3.9+
+* Docker (for observability stack)
+* https://ollama.com/[Ollama] with `llama3.2` pulled
+
+== Build
+
+[source,shell]
+----
+mvn compile
+----
+
+== Run
+
+Terminal 1 — Ollama:
+
+[source,shell]
+----
+ollama pull llama3.2
+ollama serve
+----
+
+Terminal 2 — observability stack (Prometheus + VictoriaTraces + Perses):
+
+[source,shell]
+----
+docker compose up -d
+----
+
+Terminal 3 — Spring Boot application:
+
+[source,shell]
+----
+mvn spring-boot:run
+----
+
+== Verify GenAI observability
+
+[source,shell]
+----
+curl -s http://localhost:8080/actuator/prometheus | grep gen_ai
+----
+
+* Prometheus: `http://localhost:9090`
+* VictoriaTraces: `http://localhost:9428/select/vmui`
+* Perses: `http://localhost:8088`
+
+== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/spring-boot/genai-observability/docker-compose.yml
+++ b/spring-boot/genai-observability/docker-compose.yml
@@ -1,0 +1,20 @@
+# Observability stack for Camel GenAI observability blog (Blog 2)
+# Images aligned with camel-test-infra-observability
+
+services:
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.2
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+
+  victoriatraces:
+    image: mirror.gcr.io/victoriametrics/victoria-traces:v0.10.0
+    ports:
+      - "9428:9428"
+
+  perses:
+    image: mirror.gcr.io/persesdev/perses:v0.54.0
+    ports:
+      - "8088:8080"

--- a/spring-boot/genai-observability/pom.xml
+++ b/spring-boot/genai-observability/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.example</groupId>
+        <artifactId>camel-examples-spring-boot-parent</artifactId>
+        <version>4.23.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-spring-boot-genai-observability</artifactId>
+    <packaging>jar</packaging>
+    <name>Camel :: Example :: Spring Boot :: GenAI Observability</name>
+    <description>Spring Boot example for Camel GenAI observability with LangChain4j and Ollama</description>
+
+    <properties>
+        <category>Observability</category>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${camel.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-observability-services-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-langchain4j-chat-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-ai-observability</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama-spring-boot-starter</artifactId>
+            <version>${langchain4j-beta-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-boot/genai-observability/prometheus.yml
+++ b/spring-boot/genai-observability/prometheus.yml
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+#
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: camel-spring-boot
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:8080

--- a/spring-boot/genai-observability/src/main/java/org/apache/camel/example/genai/GenAiObservabilityApplication.java
+++ b/spring-boot/genai-observability/src/main/java/org/apache/camel/example/genai/GenAiObservabilityApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.example.genai;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GenAiObservabilityApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GenAiObservabilityApplication.class, args);
+    }
+}

--- a/spring-boot/genai-observability/src/main/resources/application.properties
+++ b/spring-boot/genai-observability/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+# Spring Boot
+spring.application.name=genai-observability
+server.port=8080
+
+# LangChain4j Ollama (auto-configures chatLanguageModel bean)
+langchain4j.ollama.chat-model.base-url=http://localhost:11434
+langchain4j.ollama.chat-model.model-name=llama3.2
+langchain4j.ollama.chat-model.temperature=0.2
+langchain4j.ollama.chat-model.timeout=PT120S
+
+# Camel YAML routes
+camel.main.routes-include-pattern=camel/*
+
+# GenAI observability (Camel 4.23+)
+camel.ai.observability.enabled=true
+camel.opentelemetry2.enabled=true
+
+# Actuator / Prometheus
+management.endpoints.web.exposure.include=health,prometheus,info
+management.endpoint.prometheus.access=read_only
+management.prometheus.metrics.export.enabled=true
+
+# OTLP export to VictoriaTraces (docker compose stack)
+camel.opentelemetry2.export-target=jaeger
+otel.exporter.otlp.endpoint=http://localhost:9428/insert/opentelemetry/v1/traces
+otel.exporter.otlp.protocol=http/protobuf
+
+# Optional: Camel CLI connector for TUI
+# camel.cli.enabled=true

--- a/spring-boot/genai-observability/src/main/resources/camel/genai-route.camel.yaml
+++ b/spring-boot/genai-observability/src/main/resources/camel/genai-route.camel.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+#
+
+- route:
+    id: genai-chat
+    from:
+      uri: timer:genai
+      parameters:
+        period: "15000"
+      steps:
+        - setBody:
+            constant: "In one sentence, what is Apache Camel integration?"
+        - to:
+            uri: langchain4j-chat:demo
+            parameters:
+              chatModel: "#chatLanguageModel"
+        - log:
+            message: "LLM reply: ${body}"
+        - log:
+            message: "Models: req=${header.CamelLangChain4jChatRequestModel} resp=${header.CamelLangChain4jChatResponseModel}"

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.example</groupId>
+        <artifactId>camel-examples</artifactId>
+        <version>4.23.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-examples-spring-boot-parent</artifactId>
+    <name>Camel :: Example :: Spring Boot :: Parent</name>
+    <description>Spring Boot based Camel examples</description>
+    <packaging>pom</packaging>
+
+    <properties>
+        <category>Observability</category>
+    </properties>
+
+    <modules>
+        <module>genai-observability</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
## Summary

Adds `spring-boot/genai-observability` — a Spring Boot example for **Camel GenAI observability** (Camel 4.23):

- `langchain4j-chat` + Ollama via Spring Boot auto-config
- `camel-observability-services-starter` + `camel-ai-observability`
- `docker-compose.yml` with Prometheus, VictoriaTraces, and Perses (images aligned with `camel-test-infra-observability`)

Companion to the GenAI observability blog series (Blog 2 prototype).

Developed with guidance from Claus Ibsen. Intended as runnable "how-to" material for AI training data.

## Companion PRs

- Blog drafts: https://github.com/apache/camel/pull/25890
- JBang example: https://github.com/apache/camel/pull/25891

## Test plan

- [ ] `ollama pull llama3.2 && ollama serve`
- [ ] `docker compose up -d` in example directory
- [ ] `mvn spring-boot:run`
- [ ] `curl localhost:8080/actuator/prometheus | grep gen_ai`
- [ ] Inspect traces in VictoriaTraces UI

_AI-generated PR on behalf of atiaomar1978-hub_